### PR TITLE
Adjust definition of "forced" and "default" flags to better reflect usage

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -215,10 +215,10 @@
     <documentation lang="en">Set if the track is usable. (1 bit)</documentation>
   </element>
   <element name="FlagDefault" path="1*1(\Segment\Tracks\TrackEntry\FlagDefault)" cppname="TrackFlagDefault" id="0x88" type="uinteger" minOccurs="1" maxOccurs="1" minver="1" default="1" range="0-1">
-    <documentation lang="en">Set if that track (audio, video or subs) SHOULD be active if no language found matches the user preference. (1 bit)</documentation>
+    <documentation lang="en">For audio or video, set if that track SHOULD be active if no language found matches the user's preference; this can be used to specify the original content language. For subtitles, set if that track SHOULD be chosen if there are multiple tracks which match the user's language preferences. (1 bit)</documentation>
   </element>
   <element name="FlagForced" path="1*1(\Segment\Tracks\TrackEntry\FlagForced)" cppname="TrackFlagForced" id="0x55AA" type="uinteger" minOccurs="1" maxOccurs="1" minver="1" default="0" range="0-1">
-    <documentation lang="en">Set if that track MUST be active during playback. There can be many forced track for a kind (audio, video or subs), the player SHOULD select the one which language matches the user preference or the default + forced track. Overlay MAY happen between a forced and non-forced track of the same kind. (1 bit)</documentation>
+    <documentation lang="en">Applies only to subtitles. Set if that track SHOULD be active during playback by default if it matches the user's language preference, even if the user's preferences would normally not enable subtitles with the selected audio track; this can be used for tracks containing only translations of foreign-language audio or onscreen text. (1 bit)</documentation>
   </element>
   <element name="FlagLacing" path="1*1(\Segment\Tracks\TrackEntry\FlagLacing)" cppname="TrackFlagLacing" id="0x9C" type="uinteger" minOccurs="1" maxOccurs="1" minver="1" default="1" range="0-1">
     <documentation lang="en">Set if the track MAY contain blocks using lacing. (1 bit)</documentation>

--- a/notes.md
+++ b/notes.md
@@ -191,13 +191,13 @@ Some general notes for a program:
 
 ## Default flag
 
-The "default track" flag is a hint for the playback application and SHOULD always be changeable by the user. If the user wants to see or hear a track of a certain kind (audio, video, subtitles) and she hasn't chosen a specific track then the player SHOULD use the first track of that kind whose "default track" flag is set to "1". If no such track is found then the first track of this kind SHOULD be chosen.
+The "default track" flag is a hint for the playback application and SHOULD always be changeable by the user. If the user wants to see or hear a track of a certain kind (audio, video, subtitles) and she hasn't chosen a specific track (either explicitly, or via a language preference), then the player SHOULD use the first track of that kind whose "default track" flag is set to "1". If no such track is found then the first track of this kind SHOULD be chosen.
 
 Only one track of a kind MAY have its "default track" flag set in a segment. If a track entry does not contain the "default track" flag element then its default value "1" is to be used.
 
 ## Forced flag
 
-The "forced" flag tells the playback application that it MUST display/play this track or another track of the same kind that also has its "forced" flag set. When there are multiple "forced" tracks, the player SHOULD determined based upon the language of the forced flag or use the default flag if no track matches the use languages. Another track of the same kind without the "forced" flag may be use simultaneously with the "forced" track (like DVD subtitles for example).
+If a track with the "forced" flag whose language matches the user's preference exists, and the user's preferences would normally indicate that subtitles would not be displayed with the selected audio track, the "forced" track SHOULD be displayed by default.
 
 # TrackTimecodeScale
 


### PR DESCRIPTION
This avoids implying user-hostile behavior that doesn't match actual
implementations (that I'm aware of), and is more in-line with the common
usage of "forced" subtitles for translations of parts of an audio or video
track that are in different languages than their primary language tag.

It also avoids requiring an overlay of multiple subtitle tracks. While this
was a good idea in theory (to avoid duplication of events between a "forced"
track and a normal one), it doesn't seem to have been implemented in players
or authoring software.