### PR TITLE
add implementation_notes on conditional element attributes

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1118,7 +1118,7 @@
   </element>
   <element name="ChapterSegmentUID" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSegmentUID)" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of another Segment to play during this chapter.</documentation>
-    <documentation lang="en" purpose="usage notes">ChapterSegmentUID is mandatory if ChapterSegmentEditionUID is used.</documentation>
+    <implementation_note note_type="minOccurs">ChapterSegmentUID is MANDATORY if ChapterSegmentEditionUID is used.</implementation_note>
     <extension webm="0"/>
   </element>
   <element name="ChapterSegmentEditionUID" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSegmentEditionUID)" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -963,7 +963,8 @@
     <extension webm="0"/>
   </element>
   <element name="Cues" path="0*1(\Segment\Cues)" id="0x1C53BB6B" type="master" maxOccurs="1">
-    <documentation lang="en" purpose="definition">A Top-Level Element to speed seeking access. All entries are local to the Segment. This Element SHOULD be mandatory for non <a href="https://www.matroska.org/technical/streaming/index.hmtl">"live" streams</a>.</documentation>
+    <documentation lang="en" purpose="definition">A Top-Level Element to speed seeking access. All entries are local to the Segment.</documentation>
+    <implementation_note note_type="minOccurs">This Element SHOULD be mandatory when the Segment is not transmitted as a Livestreaming (see #livestreaming).</implementation_note>
   </element>
   <element name="CuePoint" path="1*(\Segment\Cues\CuePoint)" id="0xBB" type="master" minOccurs="1">
     <documentation lang="en" purpose="definition">Contains all information relative to a seek point in the Segment.</documentation>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -517,8 +517,9 @@
     </restriction>
     <extension cppname="VideoAspectRatio"/>
   </element>
-  <element name="ColourSpace" path="0*1(\Segment\Tracks\TrackEntry\Video\ColourSpace)" id="0x2EB524" type="binary" length="4" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specify the pixel format used for the Track's data as a FourCC. This value is similar in scope to the biCompression value of AVI's BITMAPINFOHEADER. This Element is MANDATORY in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</documentation>
+  <element name="ColourSpace" path="0*1(\Segment\Tracks\TrackEntry\Video\ColourSpace)" id="0x2EB524" type="binary" length="4" minOccurs="see note" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Specify the pixel format used for the Track's data as a FourCC. This value is similar in scope to the biCompression value of AVI's BITMAPINFOHEADER.</documentation>
+    <implementation_note note_type="minOccurs">ColourSpace is MANDATORY in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
     <extension webm="0"/>
     <extension cppname="VideoColourSpace"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -158,8 +158,10 @@
     <documentation lang="en" purpose="definition">Interpreted by the codec as it wishes (using the BlockAddID).</documentation>
     <extension webm="1"/>
   </element>
-  <element name="BlockDuration" path="0*1(\Segment\Cluster\BlockGroup\BlockDuration)" id="0x9B" type="uinteger" default="DefaultDuration" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The duration of the Block (based on TimestampScale). This Element is mandatory when DefaultDuration is set for the track (but can be omitted as other default values). When not written and with no DefaultDuration, the value is assumed to be the difference between the timestamp of this Block and the timestamp of the next Block in "display" order (not coding order). This Element can be useful at the end of a Track (as there is no other Block available), or when there is a break in a track like for subtitle tracks.</documentation>
+  <element name="BlockDuration" path="0*1(\Segment\Cluster\BlockGroup\BlockDuration)" id="0x9B" type="uinteger" default="see note" minOccurs="see note" maxOccurs="1">
+    <documentation lang="en" purpose="definition">The duration of the Block (based on TimestampScale). The BlockDuration Element can be useful at the end of a Track to define the duration of the last frame (as there is no subsequent Block available), or when there is a break in a track like for subtitle tracks.</documentation>
+    <implementation_note note_type="minOccurs">BlockDuration is a MANDATORY Element if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
+    <implementation_note note_type="default">When not written and with no DefaultDuration, the value is assumed to be the difference between the timestamp of this Block and the timestamp of the next Block in "display" order (not coding order).</implementation_note>
   </element>
   <element name="ReferencePriority" path="1*1(\Segment\Cluster\BlockGroup\ReferencePriority)" id="0xFA" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">This frame is referenced and has the specified cache priority. In cache only a frame of the same or higher priority can replace this frame. A value of 0 means the frame is not referenced.</documentation>
@@ -485,12 +487,14 @@
     <documentation lang="en" purpose="definition">The number of video pixels to remove on the right of the image.</documentation>
     <extension cppname="VideoPixelCropRight"/>
   </element>
-  <element name="DisplayWidth" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayWidth)" id="0x54B0" type="uinteger" range="not 0" default="PixelWidth - PixelCropLeft - PixelCropRight" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Width of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements). The default value is only valid when <a href="https://www.matroska.org/technical/specs/index.html#DisplayUnit">DisplayUnit</a> is 0.</documentation>
+  <element name="DisplayWidth" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayWidth)" id="0x54B0" type="uinteger" range="not 0" default="see note" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Width of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
+    <implementation_note note_type="default">If the DisplayUnit is 0, then the default value for DisplayWidth is equal to PixelWidth - PixelCropLeft - PixelCropRight, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayWidth"/>
   </element>
-  <element name="DisplayHeight" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayHeight)" id="0x54BA" type="uinteger" range="not 0" default="PixelHeight - PixelCropTop - PixelCropBottom" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Height of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements). The default value is only valid when <a href="https://www.matroska.org/technical/specs/index.html#DisplayUnit">DisplayUnit</a> is 0.</documentation>
+  <element name="DisplayHeight" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayHeight)" id="0x54BA" type="uinteger" range="not 0" default="see note" maxOccurs="1">
+    <documentation lang="en" purpose="definition">Height of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
+    <implementation_note note_type="default">If the DisplayUnit is 0, then the default value for DisplayHeight is equal to PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayHeight"/>
   </element>
   <element name="DisplayUnit" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayUnit)" id="0x54B2" type="uinteger" default="0" maxOccurs="1">
@@ -767,8 +771,9 @@
     <documentation lang="en" purpose="definition">Sampling frequency in Hz.</documentation>
     <extension cppname="AudioSamplingFreq"/>
   </element>
-  <element name="OutputSamplingFrequency" path="0*1(\Segment\Tracks\TrackEntry\Audio\OutputSamplingFrequency)" id="0x78B5" type="float" range="&gt; 0x0p+0" default="SamplingFrequency" maxOccurs="1">
+  <element name="OutputSamplingFrequency" path="0*1(\Segment\Tracks\TrackEntry\Audio\OutputSamplingFrequency)" id="0x78B5" type="float" range="&gt; 0x0p+0" default="see note" maxOccurs="1">
     <documentation lang="en" purpose="definition">Real output sampling frequency in Hz (used for SBR techniques).</documentation>
+    <implementation_note note_type="default">The default value for OutputSamplingFrequency is equal to the SampllingFrequency.</implementation_note>
     <extension cppname="AudioOutputSamplingFreq"/>
   </element>
   <element name="Channels" path="1*1(\Segment\Tracks\TrackEntry\Audio\Channels)" id="0x9F" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -489,12 +489,12 @@
   </element>
   <element name="DisplayWidth" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayWidth)" id="0x54B0" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Width of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
-    <implementation_note note_attribute="default">If the DisplayUnit is 0, then the default value for DisplayWidth is equal to PixelWidth - PixelCropLeft - PixelCropRight, else there is no default value.</implementation_note>
+    <implementation_note note_attribute="default">If the DisplayUnit of the same TrackEntry is 0, then the default value for DisplayWidth is equal to PixelWidth - PixelCropLeft - PixelCropRight, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayWidth"/>
   </element>
   <element name="DisplayHeight" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayHeight)" id="0x54BA" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Height of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
-    <implementation_note note_attribute="default">If the DisplayUnit is 0, then the default value for DisplayHeight is equal to PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</implementation_note>
+    <implementation_note note_attribute="default">If the DisplayUnit of the same TrackEntry is 0, then the default value for DisplayHeight is equal to PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayHeight"/>
   </element>
   <element name="DisplayUnit" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayUnit)" id="0x54B2" type="uinteger" default="0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -158,7 +158,7 @@
     <documentation lang="en" purpose="definition">Interpreted by the codec as it wishes (using the BlockAddID).</documentation>
     <extension webm="1"/>
   </element>
-  <element name="BlockDuration" path="0*1(\Segment\Cluster\BlockGroup\BlockDuration)" id="0x9B" type="uinteger" default="see note" minOccurs="see note" maxOccurs="1">
+  <element name="BlockDuration" path="0*1(\Segment\Cluster\BlockGroup\BlockDuration)" id="0x9B" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">The duration of the Block (based on TimestampScale). The BlockDuration Element can be useful at the end of a Track to define the duration of the last frame (as there is no subsequent Block available), or when there is a break in a track like for subtitle tracks.</documentation>
     <implementation_note note_type="minOccurs">BlockDuration is a MANDATORY Element if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
     <implementation_note note_type="default">When not written and with no DefaultDuration, the value is assumed to be the difference between the timestamp of this Block and the timestamp of the next Block in "display" order (not coding order).</implementation_note>
@@ -487,12 +487,12 @@
     <documentation lang="en" purpose="definition">The number of video pixels to remove on the right of the image.</documentation>
     <extension cppname="VideoPixelCropRight"/>
   </element>
-  <element name="DisplayWidth" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayWidth)" id="0x54B0" type="uinteger" range="not 0" default="see note" maxOccurs="1">
+  <element name="DisplayWidth" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayWidth)" id="0x54B0" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Width of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
     <implementation_note note_type="default">If the DisplayUnit is 0, then the default value for DisplayWidth is equal to PixelWidth - PixelCropLeft - PixelCropRight, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayWidth"/>
   </element>
-  <element name="DisplayHeight" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayHeight)" id="0x54BA" type="uinteger" range="not 0" default="see note" maxOccurs="1">
+  <element name="DisplayHeight" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayHeight)" id="0x54BA" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Height of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
     <implementation_note note_type="default">If the DisplayUnit is 0, then the default value for DisplayHeight is equal to PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayHeight"/>
@@ -517,7 +517,7 @@
     </restriction>
     <extension cppname="VideoAspectRatio"/>
   </element>
-  <element name="ColourSpace" path="0*1(\Segment\Tracks\TrackEntry\Video\ColourSpace)" id="0x2EB524" type="binary" length="4" minOccurs="see note" maxOccurs="1">
+  <element name="ColourSpace" path="0*1(\Segment\Tracks\TrackEntry\Video\ColourSpace)" id="0x2EB524" type="binary" length="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify the pixel format used for the Track's data as a FourCC. This value is similar in scope to the biCompression value of AVI's BITMAPINFOHEADER.</documentation>
     <implementation_note note_type="minOccurs">ColourSpace is MANDATORY in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
     <extension webm="0"/>
@@ -772,7 +772,7 @@
     <documentation lang="en" purpose="definition">Sampling frequency in Hz.</documentation>
     <extension cppname="AudioSamplingFreq"/>
   </element>
-  <element name="OutputSamplingFrequency" path="0*1(\Segment\Tracks\TrackEntry\Audio\OutputSamplingFrequency)" id="0x78B5" type="float" range="&gt; 0x0p+0" default="see note" maxOccurs="1">
+  <element name="OutputSamplingFrequency" path="0*1(\Segment\Tracks\TrackEntry\Audio\OutputSamplingFrequency)" id="0x78B5" type="float" range="&gt; 0x0p+0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Real output sampling frequency in Hz (used for SBR techniques).</documentation>
     <implementation_note note_type="default">The default value for OutputSamplingFrequency is equal to the SamplingFrequency.</implementation_note>
     <extension cppname="AudioOutputSamplingFreq"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -160,8 +160,8 @@
   </element>
   <element name="BlockDuration" path="0*1(\Segment\Cluster\BlockGroup\BlockDuration)" id="0x9B" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">The duration of the Block (based on TimestampScale). The BlockDuration Element can be useful at the end of a Track to define the duration of the last frame (as there is no subsequent Block available), or when there is a break in a track like for subtitle tracks.</documentation>
-    <implementation_note note_type="minOccurs">BlockDuration MUST be set (minOccurs=1) if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
-    <implementation_note note_type="default">When not written and with no DefaultDuration, the value is assumed to be the difference between the timestamp of this Block and the timestamp of the next Block in "display" order (not coding order).</implementation_note>
+    <implementation_note note_attribute="minOccurs">BlockDuration MUST be set (minOccurs=1) if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
+    <implementation_note note_attribute="default">When not written and with no DefaultDuration, the value is assumed to be the difference between the timestamp of this Block and the timestamp of the next Block in "display" order (not coding order).</implementation_note>
   </element>
   <element name="ReferencePriority" path="1*1(\Segment\Cluster\BlockGroup\ReferencePriority)" id="0xFA" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">This frame is referenced and has the specified cache priority. In cache only a frame of the same or higher priority can replace this frame. A value of 0 means the frame is not referenced.</documentation>
@@ -489,12 +489,12 @@
   </element>
   <element name="DisplayWidth" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayWidth)" id="0x54B0" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Width of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
-    <implementation_note note_type="default">If the DisplayUnit is 0, then the default value for DisplayWidth is equal to PixelWidth - PixelCropLeft - PixelCropRight, else there is no default value.</implementation_note>
+    <implementation_note note_attribute="default">If the DisplayUnit is 0, then the default value for DisplayWidth is equal to PixelWidth - PixelCropLeft - PixelCropRight, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayWidth"/>
   </element>
   <element name="DisplayHeight" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayHeight)" id="0x54BA" type="uinteger" range="not 0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Height of the video frames to display. Applies to the video frame after cropping (PixelCrop* Elements).</documentation>
-    <implementation_note note_type="default">If the DisplayUnit is 0, then the default value for DisplayHeight is equal to PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</implementation_note>
+    <implementation_note note_attribute="default">If the DisplayUnit is 0, then the default value for DisplayHeight is equal to PixelHeight - PixelCropTop - PixelCropBottom, else there is no default value.</implementation_note>
     <extension cppname="VideoDisplayHeight"/>
   </element>
   <element name="DisplayUnit" path="0*1(\Segment\Tracks\TrackEntry\Video\DisplayUnit)" id="0x54B2" type="uinteger" default="0" maxOccurs="1">
@@ -519,7 +519,7 @@
   </element>
   <element name="ColourSpace" path="0*1(\Segment\Tracks\TrackEntry\Video\ColourSpace)" id="0x2EB524" type="binary" length="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify the pixel format used for the Track's data as a FourCC. This value is similar in scope to the biCompression value of AVI's BITMAPINFOHEADER.</documentation>
-    <implementation_note note_type="minOccurs">ColourSpace MUST be set (minOccurs=1) in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
+    <implementation_note note_attribute="minOccurs">ColourSpace MUST be set (minOccurs=1) in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
     <extension webm="0"/>
     <extension cppname="VideoColourSpace"/>
   </element>
@@ -774,7 +774,7 @@
   </element>
   <element name="OutputSamplingFrequency" path="0*1(\Segment\Tracks\TrackEntry\Audio\OutputSamplingFrequency)" id="0x78B5" type="float" range="&gt; 0x0p+0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Real output sampling frequency in Hz (used for SBR techniques).</documentation>
-    <implementation_note note_type="default">The default value for OutputSamplingFrequency is equal to the SamplingFrequency.</implementation_note>
+    <implementation_note note_attribute="default">The default value for OutputSamplingFrequency is equal to the SamplingFrequency.</implementation_note>
     <extension cppname="AudioOutputSamplingFreq"/>
   </element>
   <element name="Channels" path="1*1(\Segment\Tracks\TrackEntry\Audio\Channels)" id="0x9F" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">
@@ -964,7 +964,7 @@
   </element>
   <element name="Cues" path="0*1(\Segment\Cues)" id="0x1C53BB6B" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">A Top-Level Element to speed seeking access. All entries are local to the Segment.</documentation>
-    <implementation_note note_type="minOccurs">This Element SHOULD be set when the Segment is not transmitted as a live stream (see #livestreaming).</implementation_note>
+    <implementation_note note_attribute="minOccurs">This Element SHOULD be set when the Segment is not transmitted as a live stream (see #livestreaming).</implementation_note>
   </element>
   <element name="CuePoint" path="1*(\Segment\Cues\CuePoint)" id="0xBB" type="master" minOccurs="1">
     <documentation lang="en" purpose="definition">Contains all information relative to a seek point in the Segment.</documentation>
@@ -1118,7 +1118,7 @@
   </element>
   <element name="ChapterSegmentUID" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSegmentUID)" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of another Segment to play during this chapter.</documentation>
-    <implementation_note note_type="minOccurs">ChapterSegmentUID MUST be set (minOccurs=1) if ChapterSegmentEditionUID is used.</implementation_note>
+    <implementation_note note_attribute="minOccurs">ChapterSegmentUID MUST be set (minOccurs=1) if ChapterSegmentEditionUID is used.</implementation_note>
     <extension webm="0"/>
   </element>
   <element name="ChapterSegmentEditionUID" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSegmentEditionUID)" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -774,7 +774,7 @@
   </element>
   <element name="OutputSamplingFrequency" path="0*1(\Segment\Tracks\TrackEntry\Audio\OutputSamplingFrequency)" id="0x78B5" type="float" range="&gt; 0x0p+0" maxOccurs="1">
     <documentation lang="en" purpose="definition">Real output sampling frequency in Hz (used for SBR techniques).</documentation>
-    <implementation_note note_attribute="default">The default value for OutputSamplingFrequency is equal to the SamplingFrequency.</implementation_note>
+    <implementation_note note_attribute="default">The default value for OutputSamplingFrequency of the same TrackEntry is equal to the SamplingFrequency.</implementation_note>
     <extension cppname="AudioOutputSamplingFreq"/>
   </element>
   <element name="Channels" path="1*1(\Segment\Tracks\TrackEntry\Audio\Channels)" id="0x9F" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -160,7 +160,7 @@
   </element>
   <element name="BlockDuration" path="0*1(\Segment\Cluster\BlockGroup\BlockDuration)" id="0x9B" type="uinteger" maxOccurs="1">
     <documentation lang="en" purpose="definition">The duration of the Block (based on TimestampScale). The BlockDuration Element can be useful at the end of a Track to define the duration of the last frame (as there is no subsequent Block available), or when there is a break in a track like for subtitle tracks.</documentation>
-    <implementation_note note_type="minOccurs">BlockDuration is a MANDATORY Element if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
+    <implementation_note note_type="minOccurs">BlockDuration MUST be set (minOccurs=1) if the associated TrackEntry stores a DefaultDuration value.</implementation_note>
     <implementation_note note_type="default">When not written and with no DefaultDuration, the value is assumed to be the difference between the timestamp of this Block and the timestamp of the next Block in "display" order (not coding order).</implementation_note>
   </element>
   <element name="ReferencePriority" path="1*1(\Segment\Cluster\BlockGroup\ReferencePriority)" id="0xFA" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
@@ -519,7 +519,7 @@
   </element>
   <element name="ColourSpace" path="0*1(\Segment\Tracks\TrackEntry\Video\ColourSpace)" id="0x2EB524" type="binary" length="4" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify the pixel format used for the Track's data as a FourCC. This value is similar in scope to the biCompression value of AVI's BITMAPINFOHEADER.</documentation>
-    <implementation_note note_type="minOccurs">ColourSpace is MANDATORY in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
+    <implementation_note note_type="minOccurs">ColourSpace MUST be set (minOccurs=1) in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</implementation_note>
     <extension webm="0"/>
     <extension cppname="VideoColourSpace"/>
   </element>
@@ -964,7 +964,7 @@
   </element>
   <element name="Cues" path="0*1(\Segment\Cues)" id="0x1C53BB6B" type="master" maxOccurs="1">
     <documentation lang="en" purpose="definition">A Top-Level Element to speed seeking access. All entries are local to the Segment.</documentation>
-    <implementation_note note_type="minOccurs">This Element SHOULD be mandatory when the Segment is not transmitted as a Livestreaming (see #livestreaming).</implementation_note>
+    <implementation_note note_type="minOccurs">This Element SHOULD be set when the Segment is not transmitted as a live stream (see #livestreaming).</implementation_note>
   </element>
   <element name="CuePoint" path="1*(\Segment\Cues\CuePoint)" id="0xBB" type="master" minOccurs="1">
     <documentation lang="en" purpose="definition">Contains all information relative to a seek point in the Segment.</documentation>
@@ -1118,7 +1118,7 @@
   </element>
   <element name="ChapterSegmentUID" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSegmentUID)" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">
     <documentation lang="en" purpose="definition">The SegmentUID of another Segment to play during this chapter.</documentation>
-    <implementation_note note_type="minOccurs">ChapterSegmentUID is MANDATORY if ChapterSegmentEditionUID is used.</implementation_note>
+    <implementation_note note_type="minOccurs">ChapterSegmentUID MUST be set (minOccurs=1) if ChapterSegmentEditionUID is used.</implementation_note>
     <extension webm="0"/>
   </element>
   <element name="ChapterSegmentEditionUID" path="0*1(\Segment\Chapters\EditionEntry\ChapterAtom\ChapterSegmentEditionUID)" id="0x6EBC" type="uinteger" range="not 0" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -774,7 +774,7 @@
   </element>
   <element name="OutputSamplingFrequency" path="0*1(\Segment\Tracks\TrackEntry\Audio\OutputSamplingFrequency)" id="0x78B5" type="float" range="&gt; 0x0p+0" default="see note" maxOccurs="1">
     <documentation lang="en" purpose="definition">Real output sampling frequency in Hz (used for SBR techniques).</documentation>
-    <implementation_note note_type="default">The default value for OutputSamplingFrequency is equal to the SampllingFrequency.</implementation_note>
+    <implementation_note note_type="default">The default value for OutputSamplingFrequency is equal to the SamplingFrequency.</implementation_note>
     <extension cppname="AudioOutputSamplingFreq"/>
   </element>
   <element name="Channels" path="1*1(\Segment\Tracks\TrackEntry\Audio\Channels)" id="0x9F" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -101,7 +101,7 @@
     </xsl:for-each>
     <xsl:if test="ebml:implementation_note">
       <xsl:text>implementation notes:&#xa;&#xa;</xsl:text>
-      <xsl:text>|type|note|&#xa;</xsl:text>
+      <xsl:text>|attribute|note|&#xa;</xsl:text>
       <xsl:text>|:---|:---|&#xa;</xsl:text>
       <xsl:for-each select="ebml:implementation_note">
         <xsl:text>| </xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -33,9 +33,9 @@
       <xsl:value-of select="@id"/>
       <xsl:text>`&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@minOccurs | ebml:implementation_note[@note_type='minOccurs']">
+    <xsl:if test="@minOccurs | ebml:implementation_note[@note_attribute='minOccurs']">
       <xsl:choose>
-        <xsl:when test="ebml:implementation_note[@note_type='minOccurs']">
+        <xsl:when test="ebml:implementation_note[@note_attribute='minOccurs']">
           <xsl:text>minOccurs: see implementation notes&#xa;&#xa;</xsl:text>
         </xsl:when>
         <xsl:otherwise>
@@ -60,9 +60,9 @@
       <xsl:value-of select="@size"/>
       <xsl:text>`&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@default | ebml:implementation_note[@note_type='default']">
+    <xsl:if test="@default | ebml:implementation_note[@note_attribute='default']">
       <xsl:choose>
-        <xsl:when test="ebml:implementation_note[@note_type='default']">
+        <xsl:when test="ebml:implementation_note[@note_attribute='default']">
           <xsl:text>default: see implementation notes&#xa;&#xa;</xsl:text>
         </xsl:when>
         <xsl:otherwise>
@@ -119,7 +119,7 @@
       <xsl:text>|:---|:---|&#xa;</xsl:text>
       <xsl:for-each select="ebml:implementation_note">
         <xsl:text>| </xsl:text>
-        <xsl:value-of select="@note_type"/>
+        <xsl:value-of select="@note_attribute"/>
         <xsl:text> | </xsl:text>
         <xsl:value-of select="."/>
         <xsl:text> |&#xa;</xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -33,10 +33,17 @@
       <xsl:value-of select="@id"/>
       <xsl:text>`&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@minOccurs">
-      <xsl:text>minOccurs: `</xsl:text>
-      <xsl:value-of select="@minOccurs"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+    <xsl:if test="@minOccurs | ebml:implementation_note[@note_type='minOccurs']">
+      <xsl:choose>
+        <xsl:when test="ebml:implementation_note[@note_type='minOccurs']">
+          <xsl:text>minOccurs: see implementation notes&#xa;&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>minOccurs: `</xsl:text>
+          <xsl:value-of select="@minOccurs"/>
+          <xsl:text>`&#xa;&#xa;</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
     <xsl:if test="@maxOccurs">
       <xsl:text>maxOccurs: `</xsl:text>
@@ -53,10 +60,17 @@
       <xsl:value-of select="@size"/>
       <xsl:text>`&#xa;&#xa;</xsl:text>
     </xsl:if>
-    <xsl:if test="@default">
-      <xsl:text>default: `</xsl:text>
-      <xsl:value-of select="@default"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+    <xsl:if test="@default | ebml:implementation_note[@note_type='default']">
+      <xsl:choose>
+        <xsl:when test="ebml:implementation_note[@note_type='default']">
+          <xsl:text>default: see implementation notes&#xa;&#xa;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>default: `</xsl:text>
+          <xsl:value-of select="@default"/>
+          <xsl:text>`&#xa;&#xa;</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
     <xsl:if test="@type">
       <xsl:text>type: `</xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -99,6 +99,19 @@
       <xsl:value-of select="."/>
       <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:for-each>
+    <xsl:if test="ebml:implementation_note">
+      <xsl:text>implementation notes:&#xa;&#xa;</xsl:text>
+      <xsl:text>|type|note|&#xa;</xsl:text>
+      <xsl:text>|:---|:---|&#xa;</xsl:text>
+      <xsl:for-each select="ebml:implementation_note">
+        <xsl:text>| </xsl:text>
+        <xsl:value-of select="@note_type"/>
+        <xsl:text> | </xsl:text>
+        <xsl:value-of select="."/>
+        <xsl:text> |&#xa;</xsl:text>
+      </xsl:for-each>
+      <xsl:text>&#xa;&#xa;</xsl:text>
+    </xsl:if>
     <xsl:for-each select="ebml:restriction">
       <xsl:text>restrictions:&#xa;&#xa;</xsl:text>
       <xsl:choose>

--- a/transforms/schema_clean.xsl
+++ b/transforms/schema_clean.xsl
@@ -75,7 +75,7 @@
   </xsl:template>
   <xsl:template match="ebml:implementation_note">
     <implementation_note>
-        <xsl:attribute name="note_type"><xsl:value-of select="@note_type"/></xsl:attribute>
+        <xsl:attribute name="note_attribute"><xsl:value-of select="@note_attribute"/></xsl:attribute>
         <xsl:apply-templates/>
     </implementation_note>
   </xsl:template>

--- a/transforms/schema_clean.xsl
+++ b/transforms/schema_clean.xsl
@@ -42,6 +42,7 @@
             <xsl:attribute name="unknownsizeallowed"><xsl:value-of select="@unknownsizeallowed"/></xsl:attribute>
         </xsl:if>
         <xsl:apply-templates select="ebml:documentation"/>
+        <xsl:apply-templates select="ebml:implementation_note"/>
         <xsl:if test="ebml:restriction">
             <restriction>
                 <xsl:for-each select="ebml:restriction/ebml:enum">
@@ -71,6 +72,12 @@
         <!-- make sure the links are kept -->
         <xsl:apply-templates/>
     </documentation>
+  </xsl:template>
+  <xsl:template match="ebml:implementation_note">
+    <implementation_note>
+        <xsl:attribute name="note_type"><xsl:value-of select="@note_type"/></xsl:attribute>
+        <xsl:apply-templates/>
+    </implementation_note>
   </xsl:template>
 
   <!-- HTML tags found in documentation -->


### PR DESCRIPTION
This PR is a proposal for an alternative to https://github.com/Matroska-Org/matroska-specification/pull/236. In some case Element attributes are conditional or have some meaning too complex to store in an Element attribute. In this case for certain attributes (such as minOccurs and default), I propose storing a reserved string such as 'note' and then storing a `<implementation_notes>` section of the Element definition that clarifies that attribute. In this example I tried this for BlockDuration which has conditional minOccurs and default attributes.

Another example would be:
```xml
<element name="ColourSpace" path="0*1(\Segment\Tracks\TrackEntry\Video\ColourSpace)" cppname="VideoColourSpace" id="0x2EB524" type="binary" minOccurs="note" maxOccurs="1" minver="1" webm="0" size="4">
  <documentation lang="en">Specify the pixel format used for the Track's data as a FourCC. This value is similar in scope to the biCompression value of AVI's BITMAPINFOHEADER.</documentation>
  <implementation_notes>
    <minOccurs>ColourSpace is MANDATORY in TrackEntry when the CodecID Element of the TrackEntry is set to "V_UNCOMPRESSED".</minOccurs>
  </implementation_notes>
</element>
```

Interesting in comments on this approach before testing it with the entire schema.