### PR TITLE
assume values not found in WebM have their default value

### DIFF
--- a/matroska_schema_section_header.md
+++ b/matroska_schema_section_header.md
@@ -5,7 +5,7 @@ In addition to the EBML Schema definition provided by the EBML Specification, Ma
 
 | attribute name | required | definition |
 |:---------------|:---------|:-----------|
-| webm           | No       | A boolean to express if the Matroska Element is also supported within version 2 of the `webm` specification. Please consider the [webm specification](http://www.webmproject.org/docs/container/) as the authoritative on `webm`. Elements with the webm boolean set to false MUST NOT be found in WebM. On the other end readers MAY assume these elements have their default value if they have one. |
+| webm           | No       | A boolean to express if the Matroska Element is also supported within version 2 of the `webm` specification. Please consider the [webm specification](http://www.webmproject.org/docs/container/) as the authoritative on `webm`. Elements with the webm boolean set to false MUST NOT be found in WebM. On the other end readers MAY assume these elements have their default value if they have one and are mandatory elements. |
 
 # Matroska Schema
 

--- a/matroska_schema_section_header.md
+++ b/matroska_schema_section_header.md
@@ -5,7 +5,7 @@ In addition to the EBML Schema definition provided by the EBML Specification, Ma
 
 | attribute name | required | definition |
 |:---------------|:---------|:-----------|
-| webm           | No       | A boolean to express if the Matroska Element is also supported within version 2 of the `webm` specification. Please consider the [webm specification](http://www.webmproject.org/docs/container/) as the authoritative on `webm`. |
+| webm           | No       | A boolean to express if the Matroska Element is also supported within version 2 of the `webm` specification. Please consider the [webm specification](http://www.webmproject.org/docs/container/) as the authoritative on `webm`. Elements with the webm boolean set to false MUST NOT be found in WebM. On the other end readers MAY assume these elements have their default value if they have one. |
 
 # Matroska Schema
 


### PR DESCRIPTION
WebM doesn't use all our elements but sometimes they are implied even though
they don't define it. For example ContentEncodingOrder.

The elements must not be in WebM files (for compliance) but a parser may need
the actual value (of ContentEncodingOrder) to make any sense. So we assume
elements have their default values if they are not found.

If this is too loose, we may have to list the elements not in WebM but which
default value should be used.