### PR TITLE
add BlockAdditionMapping to describe each BlockAdditional data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ebml_matroska_elements4rfc.md: transforms/ebml_schema2markdown4rfc.xsl matroska_
 $(OUTPUT_MATROSKA).md: index_matroska.md diagram.md matroska_schema_section_header.md ebml_matroska_elements4rfc.md ordering.md chapters.md attachments.md cues.md streaming.md menu.md notes.md
 	cat $^ | grep -v '^---' > $@
 
-$(OUTPUT_CODEC).md: index_codec.md codec_specs.md subtitles.md
+$(OUTPUT_CODEC).md: index_codec.md codec_specs.md subtitles.md block_additional_mappings_intro.md block_additional_mappings/*.md
 	cat $^ > $@
 
 $(OUTPUT_TAGS).md: index_tags.md tagging.md matroska_tagging_registry.md tagging_end.md

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -1,0 +1,44 @@
+# Block Additional Mapping
+
+Extra data or metadata can be added to each `Block` using `BlockAdditional` data. Each `BlockAdditional` contains a `BlockAddID` that identifies the kind of data it contains. When the `BlockAddID` is set to `1` then the Codec Mappings defines the contents of the `BlockAdditional Element` (see (#codec-blockadditions)). When the `BlockAddID` is set a value greater than `1`, then the contents of the `BlockAdditional Element` are defined by the `BlockAdditionalMapping Element` within the associated `Track Element` where the `BlockAddID Element` of `BlockAdditional Element` equals the `BlockAddIDValue` of the associated Track's `BlockAdditionalMapping Element`. That `BlockAdditionalMapping Element` then identifies a particular Block Additional Mapping by the `BlockAddIDType`.
+
+The following XML depicts a use of a Block Additional Mapping to associate a timecode value with a `Block`:
+
+```xml
+<Segment>
+  <!--Mandatory elements ommitted for readability-->
+  <Tracks>
+    <TrackEntry>
+      <TrackNumber>1</TrackNumber>
+      <TrackUID>568001708</TrackUID>
+      <TrackType>1</TrackType>
+      <BlockAdditionalMapping>
+        <BlockAddIDValue>2</BlockAddIDValue><!--arbitrary value used in BlockAddID-->
+        <BlockAddIDName>timecode</BlockAddIDName>
+        <BlockAddIDType>12</BlockAddIDType>
+      </BlockAdditionalMapping>
+      <CodecID>V_FFV1</CodecID>
+      <Video>
+        <PixelWidth>1920</PixelWidth>
+        <PixelHeight>1080</PixelHeight>
+      </Video>
+    </TrackEntry>
+  </Tracks>
+  <Cluster>
+    <Timestamp>3000</Timestamp>
+    <BlockGroup>
+      <Block>{binary video frame}</Block>
+      <BlockAdditions>
+        <BlockMore>
+          <BlockAddID>2</BlockAddID><!--arbitrary value from BlockAdditionalMapping-->
+          <BlockAdditional>01:00:00:00</BlockAdditional>
+        </BlockMore>
+      </BlockAdditions>
+    </BlockGroup>
+  </Cluster>
+</Segment>
+```
+
+Block Additional Mappings detail how additional data MAY be stored in the `BlockMore Element` with a `BlockAdditionMapping Element` within the `Track Element` which identifies the `BlockAdditional` content. Block Additional Mappings define the `BlockAddIDType` value reserved to identify that type of data as well as providing a label which MAY be stored within the `BlockAddIDName Element`. When the Block Additional Mapping is dependent on additional contextual information then the Mapping SHOULD describe that storage of how additional contextual information is stored within the `BlockAddIDExtraData Element`.
+
+The following Block Additional Mappings are defined.

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -15,7 +15,8 @@ The following XML depicts a use of a Block Additional Mapping to associate a tim
       <TrackUID>568001708</TrackUID>
       <TrackType>1</TrackType>
       <BlockAdditionalMapping>
-        <BlockAddIDValue>2</BlockAddIDValue><!--arbitrary value used in BlockAddID-->
+        <BlockAddIDValue>2</BlockAddIDValue><!--arbitrary value
+          used in BlockAddID-->
         <BlockAddIDName>timecode</BlockAddIDName>
         <BlockAddIDType>12</BlockAddIDType>
       </BlockAdditionalMapping>
@@ -32,7 +33,8 @@ The following XML depicts a use of a Block Additional Mapping to associate a tim
       <Block>{binary video frame}</Block>
       <BlockAdditions>
         <BlockMore>
-          <BlockAddID>2</BlockAddID><!--arbitrary value from BlockAdditionalMapping-->
+          <BlockAddID>2</BlockAddID><!--arbitrary value from
+            BlockAdditionalMapping-->
           <BlockAdditional>01:00:00:00</BlockAdditional>
         </BlockMore>
       </BlockAdditions>

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -1,6 +1,8 @@
 # Block Additional Mapping
 
-Extra data or metadata can be added to each `Block` using `BlockAdditional` data. Each `BlockAdditional` contains a `BlockAddID` that identifies the kind of data it contains. When the `BlockAddID` is set to `1` then the Codec Mappings defines the contents of the `BlockAdditional Element` (see (#codec-blockadditions)). When the `BlockAddID` is set a value greater than `1`, then the contents of the `BlockAdditional Element` are defined by the `BlockAdditionalMapping Element` within the associated `Track Element` where the `BlockAddID Element` of `BlockAdditional Element` equals the `BlockAddIDValue` of the associated Track's `BlockAdditionalMapping Element`. That `BlockAdditionalMapping Element` then identifies a particular Block Additional Mapping by the `BlockAddIDType`.
+Extra data or metadata can be added to each `Block` using `BlockAdditional` data. Each `BlockAdditional` contains a `BlockAddID` that identifies the kind of data it contains.
+When the `BlockAddID` is set to `1` the contents of the `BlockAdditional Element` are define by the Codec Mappings defines (see (#codec-blockadditions)).
+When the `BlockAddID` is set a value greater than `1`, then the contents of the `BlockAdditional Element` are defined by the `BlockAdditionalMapping Element` within the associated `Track Element` where the `BlockAddID Element` of `BlockAdditional Element` equals the `BlockAddIDValue` of the associated Track's `BlockAdditionalMapping Element`. That `BlockAdditionalMapping Element` then identifies a particular Block Additional Mapping by the `BlockAddIDType`.
 
 The following XML depicts a use of a Block Additional Mapping to associate a timecode value with a `Block`:
 

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -41,6 +41,8 @@ The following XML depicts a use of a Block Additional Mapping to associate a tim
 </Segment>
 ```
 
-Block Additional Mappings detail how additional data MAY be stored in the `BlockMore Element` with a `BlockAdditionMapping Element` within the `Track Element` which identifies the `BlockAdditional` content. Block Additional Mappings define the `BlockAddIDType` value reserved to identify that type of data as well as providing a label which MAY be stored within the `BlockAddIDName Element`. When the Block Additional Mapping is dependent on additional contextual information then the Mapping SHOULD describe that storage of how additional contextual information is stored within the `BlockAddIDExtraData Element`.
+Block Additional Mappings detail how additional data MAY be stored in the `BlockMore Element` with a `BlockAdditionMapping Element` within the `Track Element` which identifies the `BlockAdditional` content.
+Block Additional Mappings define the `BlockAddIDType` value reserved to identify that type of data as well as providing an optional label stored within the `BlockAddIDName Element`.
+When the Block Additional Mapping is dependent on additional contextual information then the Mapping SHOULD describe that storage of how additional contextual information is stored within the `BlockAddIDExtraData Element`.
 
 The following Block Additional Mappings are defined.

--- a/block_additional_mappings_intro.md
+++ b/block_additional_mappings_intro.md
@@ -43,6 +43,6 @@ The following XML depicts a use of a Block Additional Mapping to associate a tim
 
 Block Additional Mappings detail how additional data MAY be stored in the `BlockMore Element` with a `BlockAdditionMapping Element` within the `Track Element` which identifies the `BlockAdditional` content.
 Block Additional Mappings define the `BlockAddIDType` value reserved to identify that type of data as well as providing an optional label stored within the `BlockAddIDName Element`.
-When the Block Additional Mapping is dependent on additional contextual information then the Mapping SHOULD describe that storage of how additional contextual information is stored within the `BlockAddIDExtraData Element`.
+When the Block Additional Mapping is dependent on additional contextual information then the Mapping SHOULD describe how such additional contextual information is stored within the `BlockAddIDExtraData Element`.
 
 The following Block Additional Mappings are defined.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -655,7 +655,7 @@ Codec Name: [WavPack](http://www.wavpack.com/) lossless audio compressor
 
 Description: The Wavpack packets consist of a stripped header followed by the frame data. For multi-track (> 2 tracks) a frame consists of many packets. For more details, check the [WavPack muxing description](wavpack.html).
 
-Codec BlockAdditions: For hybrid A_WAVPACK4 encodings (that include a lossy encoding with a supplemental correction to produce a lossless encoding), the correction part is stored in BlockAdditional.
+Codec BlockAdditions: For hybrid `A_WAVPACK4` encodings (that include a lossy encoding with a supplemental correction to produce a lossless encoding), the correction part is stored in BlockAdditional.
 
 Initialization: none
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -48,7 +48,7 @@ Each encoding supported for storage in Matroska MUST have a defined Initializati
 
 ### Codec BlockAdditions
 
-Additional data MAY be stored within a `BlockMore Element` of the `BlockAdditional Element` that is passed to the decoder along with the content of the `Block Element`. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The following table defines the meanings of `BlockAddID` values.
+Additional data that contextualizes or supplements a `Block` can be stored within the `BlockAdditional Element` of a `BlockMore Element`. This `BlockAdditional` data MAY be passed to the associated decoder along with the content of the `Block Element`. Each `BlockAdditional` is coupled with a `BlockAddID` that identifies the kind of data it contains. The following table defines the meanings of `BlockAddID` values.
 
 BlockAddID Value | Definition
 -----------------|:---------------
@@ -56,9 +56,9 @@ BlockAddID Value | Definition
 1                | Indicates that the context of the `BlockAdditional` data is defined by the corresponding `Codec Mapping`.
 2 or greater     | `BlockAddID` values of 2 and greater are mapped to the `BlockAddIDValue` of the `BlockAdditionMapping` of the associated Track.
 
-The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply associate the `BlockMore Element` with a `BlockAdditionMapping` of the associated Track. See [the section on Block Additional Mappings](#block-additional-mappings) for more information
+The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply associate the `BlockMore Element` with a `BlockAdditionMapping` of the associated Track. See [the section on Block Additional Mappings](#block-additional-mappings) for more information.
 
-The following XML depicted the nested Elements of a `BlockGroup Element` depicting an example of Codec BlockAdditions:
+The following XML depicts the nested Elements of a `BlockGroup Element` with an example of BlockAdditions:
 
 ```xml
 <BlockGroup>
@@ -66,7 +66,7 @@ The following XML depicted the nested Elements of a `BlockGroup Element` depicti
   <BlockAdditions>
     <BlockMore>
       <BlockAddID>1</BlockAddID>
-      <BlockAdditional>{alpha channel enconding to supplement the VP9 frame}</BlockAdditional>
+      <BlockAdditional>{alpha channel encoding to supplement the VP9 frame}</BlockAdditional>
     </BlockMore>
   </BlockAdditions>
 </BlockGroup>

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -48,7 +48,15 @@ Each encoding supported for storage in Matroska MUST have a defined Initializati
 
 ### Codec BlockAdditions
 
-Additional data MAY be stored within a `BlockMore Element` of the `BlockAdditional Element` that is passed to the decoder along with the content of the `Block Element`. The `BlockAddID` value of `1` is reserved to indicate that the content of the `BlockAdditional Element` is defined by the corresponding `Codec Mapping`.
+Additional data MAY be stored within a `BlockMore Element` of the `BlockAdditional Element` that is passed to the decoder along with the content of the `Block Element`. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The following table defines the meanings of `BlockAddID` values.
+
+BlockAddID Value | Definition
+-----------------|:---------------
+0                | Invalid.
+1                | Indicates that the context of the `BlockAdditional` data is defined by the corresponding `Codec Mapping`.
+2 or greater     | `BlockAddID` values of 2 and greater are mapped to the `BlockAddIDValue` of the `BlockAdditionMapping` of the associated Track.
+
+The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply associate the `BlockMore Element` with a `BlockAdditionMapping` of the associated Track. See [the section on Block Additional Mappings](#block-additional-mappings) for more information
 
 The following XML depicted the nested Elements of a `BlockGroup Element` depicting an example of Codec BlockAdditions:
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -56,7 +56,7 @@ BlockAddID Value | Definition
 1                | Indicates that the context of the `BlockAdditional` data is defined by the corresponding `Codec Mapping`.
 2 or greater     | `BlockAddID` values of 2 and greater are mapped to the `BlockAddIDValue` of the `BlockAdditionMapping` of the associated Track.
 
-The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply associate the `BlockMore Element` with a `BlockAdditionMapping` of the associated Track. See [the section on Block Additional Mappings](#block-additional-mappings) for more information.
+The values of `BlockAddID` that are 2 of greater have no semantic meaning, but simply associate the `BlockMore Element` with a `BlockAdditionMapping` of the associated Track. See [the section on Block Additional Mappings](#block-additional-mapping) for more information.
 
 The following XML depicts the nested Elements of a `BlockGroup Element` with an example of BlockAdditions:
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -269,7 +269,7 @@ Codec Name: VP8 Codec format
 
 Description: VP8 is an open and royalty free video compression format developed by Google and created by On2 Technologies as a successor to VP7. [@!RFC6386]
 
-Codec BlockAdditions: A single-channel encoding of an alpha channel MAY be stored in `BlockAdditions`.
+Codec BlockAdditions: A single-channel encoding of an alpha channel MAY be stored in `BlockAdditions`. The `BlockAddId` of the `BlockMore` containing these data MUST be 1.
 
 Initialization: none
 
@@ -281,7 +281,7 @@ Codec Name: VP9 Codec format
 
 Description: VP9 is an open and royalty free video compression format developed by Google as a successor to VP8. [Draft VP9 Bitstream and Decoding Process Specification](https://www.webmproject.org/vp9/)
 
-Codec BlockAdditions: A single-channel encoding of an alpha channel MAY be stored in `BlockAdditions`.
+Codec BlockAdditions: A single-channel encoding of an alpha channel MAY be stored in `BlockAdditions`. The `BlockAddId` of the `BlockMore` containing these data MUST be 1.
 
 Initialization: none
 
@@ -655,7 +655,7 @@ Codec Name: [WavPack](http://www.wavpack.com/) lossless audio compressor
 
 Description: The Wavpack packets consist of a stripped header followed by the frame data. For multi-track (> 2 tracks) a frame consists of many packets. For more details, check the [WavPack muxing description](wavpack.html).
 
-Codec BlockAdditions: For hybrid `A_WAVPACK4` encodings (that include a lossy encoding with a supplemental correction to produce a lossless encoding), the correction part is stored in BlockAdditional.
+Codec BlockAdditions: For hybrid `A_WAVPACK4` encodings (that include a lossy encoding with a supplemental correction to produce a lossless encoding), the correction part is stored in BlockAdditional. The `BlockAddId` of the `BlockMore` containing these data MUST be 1.
 
 Initialization: none
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -46,6 +46,24 @@ An optional description for the encoding. This value is only intended for human 
 
 Each encoding supported for storage in Matroska MUST have a defined Initialization. The Initialization MUST describe the storage of data necessary to initialize the decoder, which MUST be stored within the `CodecPrivate Element`. When the Initialization is updated within a track then that updated Initialization data MUST be written into the `CodecState Element` of the first `Cluster` to require it. If the encoding does not require any form of Initialization then `none` MUST be used to define the Initialization and the `CodecPrivate Element` SHOULD NOT be written and MUST be ignored. Data that is defined Initialization to be stored in the `CodecPrivate Element` is known as `Private Data`.
 
+### Codec BlockAdditions
+
+Additional data MAY be stored within a `BlockMore Element` of the `BlockAdditional Element` that is passed to the decoder along with the content of the `Block Element`. The `BlockAddID` value of `1` is reserved to indicate that the content of the `BlockAdditional Element` is defined by the corresponding `Codec Mapping`.
+
+The following XML depicted the nested Elements of a `BlockGroup Element` depicting an example of Codec BlockAdditions:
+
+```xml
+<BlockGroup>
+  <Block>{Binary data of a VP9 video frame in YUV}</Block>
+  <BlockAdditions>
+    <BlockMore>
+      <BlockAddID>1</BlockAddID>
+      <BlockAdditional>{alpha channel enconding to supplement the VP9 frame}</BlockAdditional>
+    </BlockMore>
+  </BlockAdditions>
+</BlockGroup>
+```
+
 ### Citation
 
 Documentation of the associated normative and informative references for the codec is RECOMMENDED.
@@ -243,6 +261,8 @@ Codec Name: VP8 Codec format
 
 Description: VP8 is an open and royalty free video compression format developed by Google and created by On2 Technologies as a successor to VP7. [@!RFC6386]
 
+Codec BlockAdditions: A single-channel encoding of an alpha channel MAY be stored in `BlockAdditions`.
+
 Initialization: none
 
 ### V_VP9
@@ -252,6 +272,8 @@ Codec ID: V_VP9
 Codec Name: VP9 Codec format
 
 Description: VP9 is an open and royalty free video compression format developed by Google as a successor to VP8. [Draft VP9 Bitstream and Decoding Process Specification](https://www.webmproject.org/vp9/)
+
+Codec BlockAdditions: A single-channel encoding of an alpha channel MAY be stored in `BlockAdditions`.
 
 Initialization: none
 
@@ -623,7 +645,9 @@ Codec ID: A_WAVPACK4
 
 Codec Name: [WavPack](http://www.wavpack.com/) lossless audio compressor
 
-Description: The Wavpack packets consist of a stripped header followed by the frame data. For multi-track (> 2 tracks) a frame consists of many packets. For hybrid files (lossy part + correction part), the correction part is stored in an additional block (level 1). For more details, check the [WavPack muxing description](wavpack.html).
+Description: The Wavpack packets consist of a stripped header followed by the frame data. For multi-track (> 2 tracks) a frame consists of many packets. For more details, check the [WavPack muxing description](wavpack.html).
+
+Codec BlockAdditions: For hybrid A_WAVPACK4 encodings (that include a lossy encoding with a supplemental correction to produce a lossless encoding), the correction part is stored in BlockAdditional.
 
 Initialization: none
 

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -315,6 +315,26 @@
     <documentation lang="en" purpose="definition">The maximum value of <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a>. A value 0 means there is no <a href="https://www.matroska.org/technical/specs/index.html#BlockAdditions">BlockAdditions</a> for this track.</documentation>
     <extension webm="0"/>
   </element>
+  <element name="BlockAdditionMapping" path="0*(\Segment\Tracks\TrackEntry\BlockAdditionMapping)" id="0x41E4" type="master" minver="4" webm="0">
+    <documentation lang="en">Contains elements that describe each value of <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> found in the Track.</documentation>
+  </element>
+  <element name="BlockAddIDValue" path="1*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue)" id="0x41F0" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" webm="0" default="1" range="not 0">
+    <documentation lang="en">The <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> value being described. To keep MaxBlockAdditionID as low as possible, small values SHOULD be used.</documentation>
+  </element>
+  <element name="BlockAddIDName" path="0*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName)" id="0x41A4" type="string" minOccurs="0" maxOccurs="1" minver="4" webm="0">
+    <documentation lang="en">A human-friendly name describing the type of BlockAdditional data.</documentation>
+  </element>
+  <element name="BlockAddIDType" path="1*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDType)" id="0x41E7" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" webm="0" default="0">
+    <documentation lang="en">How the BlockAdditional data should be handled.</documentation>
+    <restriction>
+      <enum value="0" label="Codec Complement data (passed to the codec handler with each Frame)"/>
+      <enum value="0x2122A9" label="Timecode data (format defined in BlockAddIDExtraData)"/>
+      <enum value="0x52778064" label="RAWCooked metadata (see RAWCooked spec for BlockAdditional/BlockAddIDExtraData interpretation)"/>
+    </restriction>
+  </element>
+  <element name="BlockAddIDExtraData" path="0*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDExtraData)" id="0x41E7" type="binary" minOccurs="0" maxOccurs="1" minver="4" webm="0">
+      <documentation lang="en">Extra binary data that the BlockAddIDType can use to interpret the BlockAdditional data. The intepretation of the binary data depends on the BlockAddIDType value.</documentation>
+  </element>
   <element name="Name" path="0*1(\Segment\Tracks\TrackEntry\Name)" id="0x536E" type="utf-8" maxOccurs="1">
     <documentation lang="en" purpose="definition">A human-readable track name.</documentation>
     <extension cppname="TrackName"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -151,7 +151,7 @@
     <extension webm="1"/>
   </element>
   <element name="BlockAddID" path="1*1(\Segment\Cluster\BlockGroup\BlockAdditions\BlockMore\BlockAddID)" id="0xEE" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">An ID to identify the BlockAdditional level.</documentation>
+    <documentation lang="en" purpose="definition">An ID to identify the BlockAdditional level. A value of 1 means the BlockAdditional data is interpreted as additional data passed to the codec with the Block data.</documentation>
     <extension webm="1"/>
   </element>
   <element name="BlockAdditional" path="1*1(\Segment\Cluster\BlockGroup\BlockAdditions\BlockMore\BlockAdditional)" id="0xA5" type="binary" minOccurs="1" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -318,7 +318,7 @@
   <element name="BlockAdditionMapping" path="0*(\Segment\Tracks\TrackEntry\BlockAdditionMapping)" id="0x41E4" type="master" minver="4" webm="0">
     <documentation lang="en">Contains elements that describe each value of <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> found in the Track.</documentation>
   </element>
-  <element name="BlockAddIDValue" path="1*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue)" id="0x41F0" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" webm="0" default="1" range="not 0">
+  <element name="BlockAddIDValue" path="1*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue)" id="0x41F0" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" webm="0" range=">=2">
     <documentation lang="en">The <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> value being described. To keep MaxBlockAdditionID as low as possible, small values SHOULD be used.</documentation>
   </element>
   <element name="BlockAddIDName" path="0*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName)" id="0x41A4" type="string" minOccurs="0" maxOccurs="1" minver="4" webm="0">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -322,18 +322,13 @@
     <documentation lang="en">The <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> value being described. To keep MaxBlockAdditionID as low as possible, small values SHOULD be used.</documentation>
   </element>
   <element name="BlockAddIDName" path="0*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName)" id="0x41A4" type="string" minOccurs="0" maxOccurs="1" minver="4" webm="0">
-    <documentation lang="en">A human-friendly name describing the type of BlockAdditional data.</documentation>
+    <documentation lang="en">A human-friendly name describing the type of BlockAdditional data as defined by the associated Block Additional Mapping.</documentation>
   </element>
   <element name="BlockAddIDType" path="1*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDType)" id="0x41E7" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" webm="0" default="0">
-    <documentation lang="en">How the BlockAdditional data should be handled.</documentation>
-    <restriction>
-      <enum value="0" label="Codec Complement data (passed to the codec handler with each Frame)"/>
-      <enum value="0x2122A9" label="Timecode data (format defined in BlockAddIDExtraData)"/>
-      <enum value="0x52778064" label="RAWCooked metadata (see RAWCooked spec for BlockAdditional/BlockAddIDExtraData interpretation)"/>
-    </restriction>
+    <documentation lang="en">Stores the registered identifer of the Block Additional Mapping to define how the BlockAdditional data should be handled.</documentation>
   </element>
   <element name="BlockAddIDExtraData" path="0*1(\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDExtraData)" id="0x41E7" type="binary" minOccurs="0" maxOccurs="1" minver="4" webm="0">
-      <documentation lang="en">Extra binary data that the BlockAddIDType can use to interpret the BlockAdditional data. The intepretation of the binary data depends on the BlockAddIDType value.</documentation>
+      <documentation lang="en">Extra binary data that the BlockAddIDType can use to interpret the BlockAdditional data. The intepretation of the binary data depends on the BlockAddIDType value and the corresponding Block Additional Mapping.</documentation>
   </element>
   <element name="Name" path="0*1(\Segment\Tracks\TrackEntry\Name)" id="0x536E" type="utf-8" maxOccurs="1">
     <documentation lang="en" purpose="definition">A human-readable track name.</documentation>

--- a/notes.md
+++ b/notes.md
@@ -253,3 +253,9 @@ When playing back a track using the `TrackTimestampScale`, if the track is being
 It would be possible for a `Matroska Player` to also adjust the audio's samplerate at the same time as adjusting the timestamps if you wanted to play the two audio streams synchronously. It would also be possible to adjust the video to match the audio's speed. However, for playback, the selected track(s) timestamps SHOULD be adjusted if they need to be scaled.
 
 While the above example deals specifically with audio tracks, this element can be used to align video, audio, subtitles, or any other type of track contained in a Matroska file.
+
+## BlockAdditionMapping
+
+Extra data or metadata can be added to each frame independenly using `BlockAdditional` data. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The description of such data is done with the elements in `BlockAdditionMapping`.
+
+So far only the `BlockAddIDType` value of 0 is defined. It means the content of `BlockAdditional` is passed to the track decoder in addition of the frame data. It is up to the decoder to use the "complement" data or not and how to use them. If the `AlphaMode` flag is set, that means the extra data define an alpha layer for the video, for example in WebM it's a secondary VP8/VP9 stream.

--- a/notes.md
+++ b/notes.md
@@ -253,11 +253,3 @@ When playing back a track using the `TrackTimestampScale`, if the track is being
 It would be possible for a `Matroska Player` to also adjust the audio's samplerate at the same time as adjusting the timestamps if you wanted to play the two audio streams synchronously. It would also be possible to adjust the video to match the audio's speed. However, for playback, the selected track(s) timestamps SHOULD be adjusted if they need to be scaled.
 
 While the above example deals specifically with audio tracks, this element can be used to align video, audio, subtitles, or any other type of track contained in a Matroska file.
-
-## Block Additional Mapping
-
-Extra data or metadata can be added to each frame independenly using `BlockAdditional` data. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The description of such data is done with the elements in `BlockAdditionMapping`.
-
-A `BlockAddIDType` value of 0 is defined to mean that the content of `BlockAdditional` is passed to the track decoder in addition of the frame data. It is up to the decoder to use the "complement" data or not and how to use them. If the `AlphaMode` flag is set, that means the extra data define an alpha layer for the video, for example in WebM it's a secondary VP8/VP9 stream.
-
-Other BlockAddIDType values are defined and described by Block Additional Mappings. Block Additional Mappings detail how additional data MAY be stored in the BlockMore Element with a BlockAdditionMapping Element within the Track Element which identifies the BlockAdditional content. Block Additional Mappings define the reserved BlockAddIDType value reserved for that type of data as well as providing a label which MAY be stored within the BlockAddIDName Element. When the Block Additional Mapping is dependent on additional contextual information then the Mapping SHOULD describe that storage of how additional contextual information is stored within the BlockAddIDExtraData Element.

--- a/notes.md
+++ b/notes.md
@@ -256,6 +256,6 @@ While the above example deals specifically with audio tracks, this element can b
 
 ## BlockAdditionMapping
 
-Extra data or metadata can be added to each frame independenly using `BlockAdditional` data. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The description of such data is done with the elements in `BlockAdditionMapping`.
+Extra data or metadata can be added to each frame independenly using `BlockAdditional` data. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The `BlockAddID` value of `0` is reserved to indicate the main `Block Element`. The `BlockAddID` value of `1` is reserved to indicate that the context of the `BlockAdditional` data is defined by the corresponding `Codec Mapping`. For the `BlockAddID` values of 2 and greater the description of such data is done with the elements in `BlockAdditionMapping`.
 
 So far only the `BlockAddIDType` value of 0 is defined. It means the content of `BlockAdditional` is passed to the track decoder in addition of the frame data. It is up to the decoder to use the "complement" data or not and how to use them. If the `AlphaMode` flag is set, that means the extra data define an alpha layer for the video, for example in WebM it's a secondary VP8/VP9 stream.

--- a/notes.md
+++ b/notes.md
@@ -254,8 +254,10 @@ It would be possible for a `Matroska Player` to also adjust the audio's samplera
 
 While the above example deals specifically with audio tracks, this element can be used to align video, audio, subtitles, or any other type of track contained in a Matroska file.
 
-## BlockAdditionMapping
+## Block Additional Mapping
 
-Extra data or metadata can be added to each frame independenly using `BlockAdditional` data. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The `BlockAddID` value of `0` is reserved to indicate the main `Block Element`. The `BlockAddID` value of `1` is reserved to indicate that the context of the `BlockAdditional` data is defined by the corresponding `Codec Mapping`. For the `BlockAddID` values of 2 and greater the description of such data is done with the elements in `BlockAdditionMapping`.
+Extra data or metadata can be added to each frame independenly using `BlockAdditional` data. Each `BlockAdditional` is coupled with a `BlockAddID` that helps identify the kind of data it contains. The description of such data is done with the elements in `BlockAdditionMapping`.
 
-So far only the `BlockAddIDType` value of 0 is defined. It means the content of `BlockAdditional` is passed to the track decoder in addition of the frame data. It is up to the decoder to use the "complement" data or not and how to use them. If the `AlphaMode` flag is set, that means the extra data define an alpha layer for the video, for example in WebM it's a secondary VP8/VP9 stream.
+A `BlockAddIDType` value of 0 is defined to mean that the content of `BlockAdditional` is passed to the track decoder in addition of the frame data. It is up to the decoder to use the "complement" data or not and how to use them. If the `AlphaMode` flag is set, that means the extra data define an alpha layer for the video, for example in WebM it's a secondary VP8/VP9 stream.
+
+Other BlockAddIDType values are defined and described by Block Additional Mappings. Block Additional Mappings detail how additional data MAY be stored in the BlockMore Element with a BlockAdditionMapping Element within the Track Element which identifies the BlockAdditional content. Block Additional Mappings define the reserved BlockAddIDType value reserved for that type of data as well as providing a label which MAY be stored within the BlockAddIDName Element. When the Block Additional Mapping is dependent on additional contextual information then the Mapping SHOULD describe that storage of how additional contextual information is stored within the BlockAddIDExtraData Element.


### PR DESCRIPTION
This is similar to a TrackID + CodecID + CodecPrivate + TrackName but for extra frame data.

The `Timecode` and `RAWCooked` values may be removed and done in a separate spec. They need to define properly how to interpret the `BlockAddIDExtraData` binary data.