### PR TITLE
Add media DB identifiers

### DIFF
--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -290,6 +290,9 @@
     <tag name="LCCN" class="Identifiers" type="UTF-8">
       <description lang="en">[Library of Congress Control Number](https://www.loc.gov/marc/lccn.html)</description>
     </tag>
+    <tag name="IMDB" class="Identifiers" type="UTF-8">
+      <description lang="en">[Internet Movie Database (IMDb)](https://www.imdb.com/) identifier. 'tt' followed by at least 7 digits for Movies, TV Shows and Episodes.</description>
+    </tag>
     <tag name="PURCHASE_ITEM" class="Commercial" type="UTF-8">
       <description lang="en">URL to purchase this file. This is akin to the WPAY tag in ID3.</description>
     </tag>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -293,6 +293,9 @@
     <tag name="IMDB" class="Identifiers" type="UTF-8">
       <description lang="en">[Internet Movie Database (IMDb)](https://www.imdb.com/) identifier. 'tt' followed by at least 7 digits for Movies, TV Shows and Episodes.</description>
     </tag>
+    <tag name="TMDB" class="Identifiers" type="UTF-8">
+      <description lang="en">[The Movie Database (TMDb)](https://www.themoviedb.org/) identifier. The variable length digits string MUST be prefixed with either "movie/" or "tv/".</description>
+    </tag>
     <tag name="PURCHASE_ITEM" class="Commercial" type="UTF-8">
       <description lang="en">URL to purchase this file. This is akin to the WPAY tag in ID3.</description>
     </tag>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -296,6 +296,9 @@
     <tag name="TMDB" class="Identifiers" type="UTF-8">
       <description lang="en">[The Movie Database (TMDb)](https://www.themoviedb.org/) identifier. The variable length digits string MUST be prefixed with either "movie/" or "tv/".</description>
     </tag>
+    <tag name="TVDB" class="Identifiers" type="UTF-8">
+      <description lang="en">[The TV Database (TheTVDB)](https://www.thetvdb.com/) identifier. Variable length all-digits string identifying a TV Show.</description>
+    </tag>
     <tag name="PURCHASE_ITEM" class="Commercial" type="UTF-8">
       <description lang="en">URL to purchase this file. This is akin to the WPAY tag in ID3.</description>
     </tag>


### PR DESCRIPTION
Given the difficulty for Media Center software to accurately identify a Movie or TV Show from its filename it is here suggested to provide a standardized way to link a Matroska file to those widely used (and relied upon) databases.

Note: A TV Show and a Movie can have the same ID number on TMDb. Using their API endpoint path as a way to distinguish them: `tv/` and `movie/` as a prefix to the value.