### PR TITLE
Revert "always have a ContentEncAlgo in there is a ContentEncryption"

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -692,10 +692,10 @@
   <element name="ContentCompSettings" path="0*1(\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentCompression\ContentCompSettings)" id="0x4255" type="binary" maxOccurs="1" minver="1" webm="0">
     <documentation lang="en">Settings that might be needed by the decompressor. For Header Stripping (`ContentCompAlgo`=3), the bytes that were removed from the beggining of each frames of the track.</documentation>
   </element>
-  <element name="ContentEncryption" path="1*1(\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption)" id="0x5035" type="master" minOccurs="1" maxOccurs="1" minver="1" webm="1">
+  <element name="ContentEncryption" path="0*1(\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption)" id="0x5035" type="master" maxOccurs="1" minver="1" webm="1">
     <documentation lang="en">Settings describing the encryption used. This Element MUST be present if the value of `ContentEncodingType` is 1 (encryption) and MUST be ignored otherwise.</documentation>
   </element>
-  <element name="ContentEncAlgo" path="0*1(\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAlgo)" id="0x47E1" type="uinteger" maxOccurs="1" minver="1" webm="1" default="0">
+  <element name="ContentEncAlgo" path="1*1(\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption\ContentEncAlgo)" id="0x47E1" type="uinteger" minOccurs="1" maxOccurs="1" minver="1" webm="1" default="0">
     <documentation lang="en">The encryption algorithm used. The value '0' means that the contents have not been encrypted but only signed.</documentation>
     <restriction>
       <enum value="0" label="Not encrypted"/>


### PR DESCRIPTION
and do what was actually intended: Make `ContentEncAlgo` mandatory.

I have already explained this [here](https://github.com/Matroska-Org/matroska-specification/pull/281#issuecomment-455133872).