### PR TITLE
fix hash enum

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -737,7 +737,7 @@
     <restriction>
       <enum value="0" label="Not signed"/>
       <enum value="1" label="SHA1-160"/>
-      <enum value="1" label="MD5"/>
+      <enum value="2" label="MD5"/>
     </restriction>
   </element>
   <element name="Cues" path="0*1(\Segment\Cues)" id="0x1C53BB6B" type="master" maxOccurs="1" minver="1">


### PR DESCRIPTION
It was clearly never used but at least we have coherent values.

Also https://www.webmproject.org/docs/container/ states 2 for MD5 (but the
element is not supported)