### PR TITLE
fix typo in make process for codecs doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 _site
 .sass-cache
 *lhomme-cellar-matroska-*
-*lhomme-cellar-codecs-*
+*lhomme-cellar-codec*
 *lhomme-cellar-tags-*
 *ietf-cellar-matroska-*
-*ietf-cellar-codecs-*
+*ietf-cellar-codec*
 *ietf-cellar-tags-*
 ebml_matroska_elements.md
 ebml_matroska_elements4rfc.md

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ STATUS_MATROSKA := draft-
 STATUS_CODEC := draft-
 STATUS_TAGS := draft-
 OUTPUT_MATROSKA := $(STATUS_MATROSKA)ietf-cellar-matroska-$(VERSION_MATROSKA)
-OUTPUT_CODEC := $(STATUS_CODEC)ietf-cellar-codecs-$(VERSION_CODEC)
+OUTPUT_CODEC := $(STATUS_CODEC)ietf-cellar-codec-$(VERSION_CODEC)
 OUTPUT_TAGS := $(STATUS_TAGS)ietf-cellar-tags-$(VERSION_TAGS)
 
 XML2RFC_CALL := xml2rfc

--- a/index_codec.md
+++ b/index_codec.md
@@ -10,7 +10,7 @@ keyword = [""]
 name = "Internet Draft"
 stream = "IETF"
 status = "informational"
-value = "draft-ietf-cellar-codecs-03"
+value = "draft-ietf-cellar-codec-03"
 
 [[author]]
 initials="S."


### PR DESCRIPTION
Not sure where this regression occurred, but somewhere the name of the codecs output from changed from `codec` to `codecs`. The IETF data tracker thus sees updates as discontinuous, so I set it back.