### PR TITLE
Remove contradictory statements on Blocks

### DIFF
--- a/index_matroska.md
+++ b/index_matroska.md
@@ -144,8 +144,6 @@ Bit 0 is the most significant bit.
 
 Frames using references SHOULD be stored in "coding order". That means the references first and then the frames referencing them. A consequence is that timestamps might not be consecutive. But a frame with a past timestamp MUST reference a frame already known, otherwise it's considered bad/void.
 
-There can be many Blocks in a BlockGroup provided they all have the same timestamp. It is used with different parts of a frame with different priorities.
-
 #### Block Header
 
 | Offset | Player | Description |
@@ -226,8 +224,6 @@ The `SimpleBlock` is inspired by the [Block structure](#block-structure). The ma
 Bit 0 is the most significant bit.
 
 Frames using references SHOULD be stored in "coding order". That means the references first and then the frames referencing them. A consequence is that timestamps might not be consecutive. But a frame with a past timestamp MUST reference a frame already known, otherwise it's considered bad/void.
-
-There can be many `Block Elements` in a `BlockGroup` provided they all have the same timestamp. It is used with different parts of a frame with different priorities.
 
 ##### SimpleBlock Header
 


### PR DESCRIPTION
The `Block` element has [`maxOccurs="1"`](https://github.com/cellar-wg/matroska-specification/blob/a577e0da858f56688ffedb975a49cbfacddc667c/ebml_matroska.xml#L138).

See https://mailarchive.ietf.org/arch/msg/cellar/3VzyQMOQkMAh305jRTznhhiXZRM