### PR TITLE
Add AVC and HEVC codec mappings

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -182,6 +182,26 @@ Description: The Matroska video stream will contain a demuxed Elementary Stream 
 
 Initialization: none
 
+### V_MPEG4/ISO/AVC
+
+Codec ID: V_MPEG4/ISO/AVC
+
+Codec Name: AVC/H.264
+
+Description: Individual pictures of AVC/H.264 stored as described in [@!ISO.14496-15.2014].
+
+Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014], optionally followed by one or more [extension blocks](#private-data-extension-blocks).
+
+### V_MPEGH/ISO/HEVC
+
+Codec ID: V_MPEGH/ISO/HEVC
+
+Codec Name: HEVC/H.265
+
+Description: Individual pictures of HEVC/H.265 stored as described in [@!ISO.14496-15.2014].
+
+Initialization: The `Private Data` contains a `HEVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014], optionally followed by one or more [extension blocks](#private-data-extension-blocks).
+
 ### V_REAL/RV10
 
 Codec ID: V_REAL/RV10
@@ -763,3 +783,8 @@ Codec Name: VobBtn Buttons
 
 Description: Based on [MPEG/VOB PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html). The file contains a header consisting of the string "butonDVD" followed by the width and height in pixels (16 bits integer each) and 4 reserved bytes. The rest is full [PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html).
 
+## Private Data Extension Blocks
+
+When indicated in the codec description as possible, `Private Data` codec specific data MAY be followed by one or more extension blocks.
+
+Each extension block begins with a 4-byte extension block size field which is the size of the extension block minus 4 (excluding the size of the extension block size field), followed by an extension block identifier field.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -788,3 +788,29 @@ Description: Based on [MPEG/VOB PCI packets](http://dvd.sourceforge.net/dvdinfo/
 When indicated in the codec description as possible, `Private Data` codec specific data MAY be followed by one or more extension blocks.
 
 Each extension block begins with a 4-byte extension block size field which is the size of the extension block minus 4 (excluding the size of the extension block size field), followed by an extension block identifier field.
+
+Registered `Private Data` extension block identifier fields are:
+
+### dvcC
+
+Block identifier: 0x64766343
+
+Extension name: Dolby Vision configuration
+
+Description: `DOVIDecoderConfigurationRecord` structure as defined in [Dolby Vision Streams File Format](https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf).
+
+### hvcE
+
+Block identifier: 0x68766345
+
+Extension name: Dolby Vision enhancement-layer HEVC configuration
+
+Description: `HEVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014], as described in [Dolby Vision Streams File Format](https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf). This extension MUST NOT be used if `Codec ID` is not `V_MPEGH/ISO/HEVC`.
+
+### mvcC
+
+Block identifier: 0x6D766343
+
+Extension name: MVC configuration
+
+Description: `MVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014]. This extension MUST NOT be used if `Codec ID` is not `V_MPEG4/ISO/AVC`.

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -22,3 +22,14 @@
   </front>
   <seriesInfo name="IEEE" value="Standard 754" />
 </reference>
+
+<reference anchor="ISO.14496-15.2014">
+  <front>
+    <title>Information technology — Coding of audio-visual objects — Part 15: Carriage of network abstraction layer (NAL) unit structured video in ISO base media file format</title>
+    <author>
+      <organization>International Organization for Standardization</organization>
+    </author>
+    <date month="" year="2014" />
+  </front>
+  <seriesInfo name="ISO" value="Standard 14496" />
+</reference>


### PR DESCRIPTION
AVC and HEVC are widely used in Matroska, but without explicit codec mapping.

This PR adds the mapping of AVC and HEVC in Matroska, including the definition of extension blocks in `CodecPrivate`.

Fix #373.