### PR TITLE
support `rationale` and `references` documentation in the website table

### DIFF
--- a/transforms/ebml_schema2spec_common.xsl
+++ b/transforms/ebml_schema2spec_common.xsl
@@ -303,9 +303,17 @@
       </td>
       <td>
         <xsl:apply-templates select="ebml:documentation[@purpose='definition']"/>
+        <xsl:if test="ebml:documentation[@purpose='rationale']">
+          <xsl:text> </xsl:text>
+          <xsl:apply-templates select="ebml:documentation[@purpose='rationale']"/>
+        </xsl:if>
         <xsl:if test="ebml:documentation[@purpose='usage notes']">
           <xsl:text> </xsl:text>
           <xsl:apply-templates select="ebml:documentation[@purpose='usage notes']"/>
+        </xsl:if>
+        <xsl:if test="ebml:documentation[@purpose='references']">
+          <xsl:text> </xsl:text>
+          <xsl:apply-templates select="ebml:documentation[@purpose='references']"/>
         </xsl:if>
         <xsl:if test="ebml:implementation_note[@note_attribute='default']">
           <xsl:text> </xsl:text>


### PR DESCRIPTION
As I suggested using `rationale` for "Semantics" section in the current `ebml_matroska.xml` it's better if they are actually used in the output documentation.