### PR TITLE
Add AVC and HEVC codec mappings with BlockAdditionMapping

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -182,6 +182,26 @@ Description: The Matroska video stream will contain a demuxed Elementary Stream 
 
 Initialization: none
 
+### V_MPEG4/ISO/AVC
+
+Codec ID: V_MPEG4/ISO/AVC
+
+Codec Name: AVC/H.264
+
+Description: Individual pictures of AVC/H.264 stored as described in [@!ISO.14496-15.2014].
+
+Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014].
+
+### V_MPEGH/ISO/HEVC
+
+Codec ID: V_MPEGH/ISO/HEVC
+
+Codec Name: HEVC/H.265
+
+Description: Individual pictures of HEVC/H.265 stored as described in [@!ISO.14496-15.2014].
+
+Initialization: The `Private Data` contains a `HEVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014].
+
 ### V_REAL/RV10
 
 Codec ID: V_REAL/RV10

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -190,7 +190,7 @@ Codec Name: AVC/H.264
 
 Description: Individual pictures of AVC/H.264 stored as described in [@!ISO.14496-15.2014].
 
-Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014].
+Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014]; for legacy reasons ([Private Data Extension Blocks](#private-data-extension-blocks) are prefered), the `AVCDecoderConfigurationRecord` structure MAY be followed by an extension block beginning with a 4-byte extension block size field which is the size of the extension block minus 4 (excluding the size of the extension block size field) and an extension block content field identical to `BlockAddIDExtraData` content when `BlockAddIDType` is `3`.
 
 ### V_MPEGH/ISO/HEVC
 
@@ -783,3 +783,8 @@ Codec Name: VobBtn Buttons
 
 Description: Based on [MPEG/VOB PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html). The file contains a header consisting of the string "butonDVD" followed by the width and height in pixels (16 bits integer each) and 4 reserved bytes. The rest is full [PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html).
 
+## Block Addition Mappings
+
+When a `BlockAdditionMapping` element is in the `TrackEntry` and the corresponding `BlockAddIDType` value is `3`, ISOBMFF-like extensions are used.
+
+`BlockAddIDExtraData` element begins with a 4-byte extension block addition identifier field followed by the content corresponding to this identifier.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -788,3 +788,29 @@ Description: Based on [MPEG/VOB PCI packets](http://dvd.sourceforge.net/dvdinfo/
 When a `BlockAdditionMapping` element is in the `TrackEntry` and the corresponding `BlockAddIDType` value is `3`, ISOBMFF-like extensions are used.
 
 `BlockAddIDExtraData` element begins with a 4-byte extension block addition identifier field followed by the content corresponding to this identifier.
+
+Registered block addition identifier fields are:
+
+### dvcC
+
+Block identifier: 0x64766343
+
+Extension name: Dolby Vision configuration
+
+Content description: `DOVIDecoderConfigurationRecord` structure as defined in [Dolby Vision Streams File Format](https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf).
+
+### hvcE
+
+Block identifier: 0x68766345
+
+Extension name: Dolby Vision enhancement-layer HEVC configuration
+
+Content description: `HEVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014], as described in [Dolby Vision Streams File Format](https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf). This extension MUST NOT be used if `Codec ID` is not `V_MPEGH/ISO/HEVC`.
+
+### mvcC
+
+Block identifier: 0x6D766343
+
+Extension name: MVC configuration
+
+Content description: `MVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014]. This extension MUST NOT be used if `Codec ID` is not `V_MPEG4/ISO/AVC`.

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -151,11 +151,11 @@
     <extension webm="1"/>
   </element>
   <element name="BlockAddID" path="\Segment\Cluster\BlockGroup\BlockAdditions\BlockMore\BlockAddID" id="0xEE" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">An ID to identify the BlockAdditional level. A value of 1 means the BlockAdditional data is interpreted as additional data passed to the codec with the Block data.</documentation>
+    <documentation lang="en" purpose="definition">An ID to identify the BlockAdditional level. If BlockAddIDType of the corresponding track is 0, for VP9, 0x01 is reserved and 0x04 indicates ITU T.35 metadata as defined by ITU-T T.35 terminal codes; otherwise the value refers to the BlockAddIDValue value used in the corresponding BlockAdditionMapping element.</documentation>
     <extension webm="1"/>
   </element>
   <element name="BlockAdditional" path="\Segment\Cluster\BlockGroup\BlockAdditions\BlockMore\BlockAdditional" id="0xA5" type="binary" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Interpreted by the codec as it wishes (using the BlockAddID).</documentation>
+    <documentation lang="en" purpose="definition">Interpreted by the codec as it wishes (using BlockAddIDType and BlockAddID).</documentation>
     <extension webm="1"/>
   </element>
   <element name="BlockDuration" path="\Segment\Cluster\BlockGroup\BlockDuration" id="0x9B" type="uinteger" maxOccurs="1">
@@ -318,11 +318,11 @@
     <extension webm="0"/>
   </element>
   <element name="BlockAdditionMapping" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping" id="0x41E4" type="master" minver="4">
-    <documentation lang="en" purpose="definition">Contains elements that describe each value of <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> found in the Track.</documentation>
+    <documentation lang="en" purpose="definition">Contains elements that extend the track format, by adding content either to frames (with <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a>) or to the format definition</documentation>
     <extension webm="0"/>
   </element>
-  <element name="BlockAddIDValue" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue" id="0x41F0" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" range=">=2">
-    <documentation lang="en" purpose="definition">The <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> value being described. To keep MaxBlockAdditionID as low as possible, small values SHOULD be used.</documentation>
+  <element name="BlockAddIDValue" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue" id="0x41F0" type="uinteger" maxOccurs="1" minver="4" range=">=2">
+    <documentation lang="en" purpose="definition">If the track format extension needs content beside frames, the value refers to the <a href="https://www.matroska.org/technical/specs/index.html#BlockAddID">BlockAddID</a> value being described. To keep MaxBlockAdditionID as low as possible, small values SHOULD be used.</documentation>
     <extension webm="0"/>
   </element>
   <element name="BlockAddIDName" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName" id="0x41A4" type="string" maxOccurs="1" minver="4">
@@ -332,7 +332,21 @@
   <element name="BlockAddIDType" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDType" id="0x41E7" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" default="0">
     <documentation lang="en" purpose="definition">Stores the registered identifer of the Block Additional Mapping to define how the BlockAdditional data should be handled.</documentation>
     <extension webm="0"/>
-  </element>
+    <restriction>
+      <enum value="0" label="BlockAddIDValue defines the content type">
+        <documentation lang="en" purpose="definition">This value indicates that BlockAddIDValue defines the content type, and a list of content type is in BlockAddID documentation.</documentation>
+      </enum>
+      <enum value="1" label="Codec specific content">
+        <documentation lang="en" purpose="definition">This value indicates that BlockAddIDExtraData defines the content type, and this definition depends on the Codec ID used. A transcoder SHOULD discard this content if the addition is not supported</documentation>
+      </enum>
+      <enum value="2" label="General purpose content">
+        <documentation lang="en" purpose="definition">This value indicates that BlockAddIDExtraData defines the content type, and this definition does not depend on the Codec ID used. A transcoder SHOULD NOT discard this content if the addition is not supported</documentation>
+      </enum>
+      <enum value="3" label="ISOBMFF-like extension">
+        <documentation lang="en" purpose="definition">This value indicates that BlockAddIDExtraData consists of a 32-bit type field and an arbitrary large content field. The values used for both fields are the same as used in header atoms in ISOBMFF files and its extensions such as the "mvcC" box in ISO 14496-15:2014. As it is not expected that ISOBMFF-like extension have frame related content, BlockAddIDValue SHOULD NOT be present.</documentation>
+      </enum>
+    </restriction>
+    </element>
   <element name="BlockAddIDExtraData" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDExtraData" id="0x41ED" type="binary" maxOccurs="1" minver="4">
     <documentation lang="en" purpose="definition">Extra binary data that the BlockAddIDType can use to interpret the BlockAdditional data. The intepretation of the binary data depends on the BlockAddIDType value and the corresponding Block Additional Mapping.</documentation>
     <extension webm="0"/>

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -22,3 +22,14 @@
   </front>
   <seriesInfo name="IEEE" value="Standard 754" />
 </reference>
+
+<reference anchor="ISO.14496-15.2014">
+  <front>
+    <title>Information technology — Coding of audio-visual objects — Part 15: Carriage of network abstraction layer (NAL) unit structured video in ISO base media file format</title>
+    <author>
+      <organization>International Organization for Standardization</organization>
+    </author>
+    <date month="" year="2014" />
+  </front>
+  <seriesInfo name="ISO" value="Standard 14496" />
+</reference>


### PR DESCRIPTION
This PR is an alternative proposal for https://github.com/cellar-wg/matroska-specification/pull/377.
Note that it was started before https://github.com/cellar-wg/matroska-specification/pull/388, I used some wording from this PR so this PR would replace both of them.

In my opinion `BlockAdditionMapping` was not clear enough, especially the  `BlockAddIDType` part and its compatibility with WebM, so I expect to clarify the use of  `BlockAddIDType`.

I use `BlockAddIDType` of 0 (the default) for the compatibility with WebM, especially the fact that `BlockAddIDValue` defines the content in WebM if I well understand.

I was expecting to use `BlockAdditionMapping` for Codec independent content, so I "reserve" `BlockAddIDType` value 1 & 2 for specifying if the `BlockAdditionMapping` is dependent or not dependent of the Codec. For example a Codec dependent addition would be the extension of a codec transforming the main lossy data to lossless, with the same Codec (if the main content codec changes, this addition is no more usable, a transcoder must trash the addition), and a Codec independent addition would be the same except that the addition content format is specific and not dependent on the main content format (I think to my project RAWcooked here, I could convert main data from JPEG-2000 lossless to FFV1, the RAWcooked addition would not change, a transcoder should keep the addition; it could also be 608 Closed Caption or Bar Data).

`BlockAddIDType` value 3 would be for ISOBMFF-like stuff. I don't refer to "CodecPrivate extension" in my wording as ISOBMFF stuff does not rely on it, I prefer to keep it more generic for the future.