### PR TITLE
Add AVC and HEVC codec mappings with BlockAdditionMapping 2

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -803,3 +803,51 @@ Block type identifier: 1
 Block type name: Opaque data
 
 Description: the `BlockAdditional` data is interpreted as opaque additional data passed to the codec with the Block data. `BlockAddIDValue` MUST be 1.
+
+### ITU T.35 metadata
+
+Block type identifier: 4
+
+Block type name: ITU T.35 metadata
+
+Description: the `BlockAdditional` data is interpreted as ITU T.35 metadata as defined by ITU-T T.35 terminal codes. `BlockAddIDValue` MUST be 4.
+
+### avcE
+
+Block type identifier: 0x61766345
+
+Block type name: Dolby Vision enhancement-layer AVC configuration
+
+Type Description: the `BlockAddIDExtraData` data is interpreted as the Dolby Vision enhancement-layer AVC configuration box as described in [@!DolbyVisionWithinIso.2020-02]. This extension MUST NOT be used if `Codec ID` is not `V_MPEG4/ISO/AVC`.
+
+### dvcC
+
+Block type identifier: 0x64766343
+
+Block type name: Dolby Vision configuration
+
+Description: the `BlockAddIDExtraData` data is interpreted as `DOVIDecoderConfigurationRecord` structure as defined in [@!DolbyVisionWithinIso.2020-02], for Dolby Vision profiles less than and equal to 7.
+
+### dvvC
+
+Block type identifier: 0x664767643
+
+Block type name: Dolby Vision configuration
+
+Description: the `BlockAddIDExtraData` data is interpreted as `DOVIDecoderConfigurationRecord` structure as defined in [@!DolbyVisionWithinIso.2020-02], for Dolby Vision profiles greater than 7.
+
+### hvcE
+
+Block type identifier: 0x68766345
+
+Block type name: Dolby Vision enhancement-layer HEVC configuration
+
+Type Description: the `BlockAddIDExtraData` data is interpreted as the Dolby Vision enhancement-layer HEVC configuration as described in [@!DolbyVisionWithinIso.2020-02]. This extension MUST NOT be used if `Codec ID` is not `V_MPEGH/ISO/HEVC`.
+
+### mvcC
+
+Block type identifier: 0x6D766343
+
+Block type name: MVC configuration
+
+Description: the `BlockAddIDExtraData` data is interpreted as `MVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014]. This extension MUST NOT be used if `Codec ID` is not `V_MPEG4/ISO/AVC`.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -784,3 +784,22 @@ Codec Name: VobBtn Buttons
 
 Description: Based on [MPEG/VOB PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html). The file contains a header consisting of the string "butonDVD" followed by the width and height in pixels (16 bits integer each) and 4 reserved bytes. The rest is full [PCI packets](http://dvd.sourceforge.net/dvdinfo/pci_pkt.html).
 
+## Block Addition Mappings
+
+Registered `BlockAddIDType` are:
+
+### Use BlockAddIDValue
+
+Block type identifier: 0
+
+Block type name: Use BlockAddIDValue
+
+Description: This value indicates that the actual type is stored in `BlockAddIDValue` instead. This value is expected to be used when it is important to have a strong compatibility with players or derived formats not supporting `BlockAdditionMapping` but using `BlockAdditions` with an unknown `BlockAddIDValue`, and SHOULD NOT be used if it is possible to use another value.
+
+### Opaque data
+
+Block type identifier: 1
+
+Block type name: Opaque data
+
+Description: the `BlockAdditional` data is interpreted as opaque additional data passed to the codec with the Block data. `BlockAddIDValue` MUST be 1.

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -183,6 +183,26 @@ Description: The Matroska video stream will contain a demuxed Elementary Stream 
 
 Initialization: none
 
+### V_MPEG4/ISO/AVC
+
+Codec ID: V_MPEG4/ISO/AVC
+
+Codec Name: AVC/H.264
+
+Description: Individual pictures of AVC/H.264 stored as described in [@!ISO.14496-15.2014].
+
+Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014].
+
+### V_MPEGH/ISO/HEVC
+
+Codec ID: V_MPEGH/ISO/HEVC
+
+Codec Name: HEVC/H.265
+
+Description: Individual pictures of HEVC/H.265 stored as described in [@!ISO.14496-15.2014].
+
+Initialization: The `Private Data` contains a `HEVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014].
+
 ### V_REAL/RV10
 
 Codec ID: V_REAL/RV10

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -191,7 +191,7 @@ Codec Name: AVC/H.264
 
 Description: Individual pictures of AVC/H.264 stored as described in [@!ISO.14496-15.2014].
 
-Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014].
+Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014]. For legacy reasons ([Block Addition Mappings](#block-addition-mappings) are preferred), the `AVCDecoderConfigurationRecord` structure MAY be followed by an extension block beginning with a 4-byte extension block size field in Big Endian byte order which is the size of the extension block minus 4 (excluding the size of the extension block size field) and a 4-byte field corresponding to a `BlockAddIDType` of `[mvcC](#mvcC)` followed by a content corresponding to the content of `BlockAddIDExtraData` for `[mvcC](#mvcC)`.
 
 ### V_MPEGH/ISO/HEVC
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -189,7 +189,7 @@ Codec ID: V_MPEG4/ISO/AVC
 
 Codec Name: AVC/H.264
 
-Description: Individual pictures of AVC/H.264 stored as described in [@!ISO.14496-15.2014].
+Description: Individual pictures (which could be a frame, a field, or 2 fields having the same timestamp) of AVC/H.264 stored as described in [@!ISO.14496-15.2014].
 
 Initialization: The `Private Data` contains a `AVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014]. For legacy reasons ([Block Addition Mappings](#block-addition-mappings) are preferred), the `AVCDecoderConfigurationRecord` structure MAY be followed by an extension block beginning with a 4-byte extension block size field in Big Endian byte order which is the size of the extension block minus 4 (excluding the size of the extension block size field) and a 4-byte field corresponding to a `BlockAddIDType` of `[mvcC](#mvcC)` followed by a content corresponding to the content of `BlockAddIDExtraData` for `[mvcC](#mvcC)`.
 
@@ -199,7 +199,7 @@ Codec ID: V_MPEGH/ISO/HEVC
 
 Codec Name: HEVC/H.265
 
-Description: Individual pictures of HEVC/H.265 stored as described in [@!ISO.14496-15.2014].
+Description: Individual pictures (which could be a frame, a field, or 2 fields having the same timestamp) of HEVC/H.265 stored as described in [@!ISO.14496-15.2014].
 
 Initialization: The `Private Data` contains a `HEVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15.2014].
 

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -150,7 +150,7 @@
     <extension webm="1"/>
   </element>
   <element name="BlockAddID" path="\Segment\Cluster\BlockGroup\BlockAdditions\BlockMore\BlockAddID" id="0xEE" type="uinteger" range="not 0" default="1" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">An ID to identify the BlockAdditional level. A value of 1 means the BlockAdditional data is interpreted as additional data passed to the codec with the Block data.</documentation>
+    <documentation lang="en" purpose="definition">An ID to identify the BlockAdditional level. If BlockAddIDType of the corresponding block is 0, this value is also the value of BlockAddIDType for the meaning of the content of BlockAdditional.</documentation>
     <extension webm="1"/>
   </element>
   <element name="BlockAdditional" path="\Segment\Cluster\BlockGroup\BlockAdditions\BlockMore\BlockAdditional" id="0xA5" type="binary" minOccurs="1" maxOccurs="1">
@@ -317,11 +317,11 @@
     <extension webm="0"/>
   </element>
   <element name="BlockAdditionMapping" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping" id="0x41E4" type="master" minver="4">
-    <documentation lang="en" purpose="definition">Contains elements that describe each value of <a href="https://www.matroska.org/technical/elements.html#BlockAddID">BlockAddID</a> found in the Track.</documentation>
+    <documentation lang="en" purpose="definition">Contains elements that extend the track format, by adding content either to each frame (with <a href="https://www.matroska.org/technical/specs/elements.html#BlockAddID">BlockAddID</a>) or to the track as a whole (with <a href="https://www.matroska.org/technical/specs/elements.html#BlockAddIDExtraData">BlockAddIDExtraData</a>)</documentation>
     <extension webm="0"/>
   </element>
-  <element name="BlockAddIDValue" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue" id="0x41F0" type="uinteger" minOccurs="1" maxOccurs="1" minver="4" range=">=2">
-    <documentation lang="en" purpose="definition">The <a href="https://www.matroska.org/technical/elements.html#BlockAddID">BlockAddID</a> value being described. To keep MaxBlockAdditionID as low as possible, small values SHOULD be used.</documentation>
+  <element name="BlockAddIDValue" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue" id="0x41F0" type="uinteger" maxOccurs="1" minver="4" range=">=2">
+    <documentation lang="en" purpose="definition">If the track format extension needs content beside frames, the value refers to the <a href="https://www.matroska.org/technical/specs/elements.html#BlockAddID">BlockAddID</a> value being described. To keep MaxBlockAdditionID as low as possible, small values SHOULD be used.</documentation>
     <extension webm="0"/>
   </element>
   <element name="BlockAddIDName" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDName" id="0x41A4" type="string" maxOccurs="1" minver="4">

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -22,3 +22,14 @@
   </front>
   <seriesInfo name="IEEE" value="Standard 754" />
 </reference>
+
+<reference anchor="ISO.14496-15.2014">
+  <front>
+    <title>Information technology — Coding of audio-visual objects — Part 15: Carriage of network abstraction layer (NAL) unit structured video in ISO base media file format</title>
+    <author>
+      <organization>International Organization for Standardization</organization>
+    </author>
+    <date month="" year="2014" />
+  </front>
+  <seriesInfo name="ISO" value="Standard 14496" />
+</reference>

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -33,3 +33,13 @@
   </front>
   <seriesInfo name="ISO" value="Standard 14496" />
 </reference>
+
+<reference anchor="DolbyVisionWithinIso.2020-02" target="https://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-bitstreams-within-the-iso-base-media-file-format-v2.1.2.pdf">
+  <front>
+    <title>Dolby Vision Streams Within the ISO Base MediaFile Format</title>
+    <author>
+      <organization>Dolby</organization>
+    </author>
+    <date day="7" month="February" year="2020" />
+  </front>
+</reference>


### PR DESCRIPTION
Another alternative of #377, using `BlockAddIDType` for storing 4-byte ISOBMFF values.
Discussion on https://github.com/cellar-wg/matroska-specification/issues/373#issuecomment-633879582.