### PR TITLE
Use the same format for EBML elements as in the EBML RFC

### DIFF
--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -24,9 +24,9 @@
       <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@path">
-      <xsl:text>path:&#xa;: </xsl:text>
+      <xsl:text>path:&#xa;: `</xsl:text>
       <xsl:value-of select="@path"/>
-      <xsl:text>&#xa;&#xa;</xsl:text>
+      <xsl:text>`&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@id">
       <xsl:text>id:&#xa;: </xsl:text>

--- a/transforms/ebml_schema2markdown4rfc.xsl
+++ b/transforms/ebml_schema2markdown4rfc.xsl
@@ -19,19 +19,19 @@
     <xsl:value-of select="@name"/>
     <xsl:text> Element&#xa;&#xa;</xsl:text>
     <xsl:if test="@name">
-      <xsl:text>name: `</xsl:text>
+      <xsl:text>name:&#xa;: </xsl:text>
       <xsl:value-of select="@name"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@path">
-      <xsl:text>path: `</xsl:text>
+      <xsl:text>path:&#xa;: </xsl:text>
       <xsl:value-of select="@path"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@id">
-      <xsl:text>id: `</xsl:text>
+      <xsl:text>id:&#xa;: </xsl:text>
       <xsl:value-of select="@id"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@minOccurs | ebml:implementation_note[@note_attribute='minOccurs']">
       <xsl:choose>
@@ -39,26 +39,26 @@
           <xsl:text>minOccurs: see implementation notes&#xa;&#xa;</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:text>minOccurs: `</xsl:text>
+          <xsl:text>minOccurs:&#xa;: </xsl:text>
           <xsl:value-of select="@minOccurs"/>
-          <xsl:text>`&#xa;&#xa;</xsl:text>
+          <xsl:text>&#xa;&#xa;</xsl:text>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:if>
     <xsl:if test="@maxOccurs">
-      <xsl:text>maxOccurs: `</xsl:text>
+      <xsl:text>maxOccurs:&#xa;: </xsl:text>
       <xsl:value-of select="@maxOccurs"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@range">
-      <xsl:text>range: `</xsl:text>
+      <xsl:text>range:&#xa;: </xsl:text>
       <xsl:value-of select="@range"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@size">
-      <xsl:text>size: `</xsl:text>
+      <xsl:text>size:&#xa;: </xsl:text>
       <xsl:value-of select="@size"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@default | ebml:implementation_note[@note_attribute='default']">
       <xsl:choose>
@@ -66,41 +66,41 @@
           <xsl:text>default: see implementation notes&#xa;&#xa;</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:text>default: `</xsl:text>
+          <xsl:text>default:&#xa;: </xsl:text>
           <xsl:value-of select="@default"/>
-          <xsl:text>`&#xa;&#xa;</xsl:text>
+          <xsl:text>&#xa;&#xa;</xsl:text>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:if>
     <xsl:if test="@type">
-      <xsl:text>type: `</xsl:text>
+      <xsl:text>type:&#xa;: </xsl:text>
       <xsl:value-of select="@type"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@unknownsizeallowed">
-      <xsl:text>unknownsizeallowed: `</xsl:text>
+      <xsl:text>unknownsizeallowed:&#xa;: </xsl:text>
       <xsl:value-of select="@unknownsizeallowed"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@recursive">
-      <xsl:text>recursive: `</xsl:text>
+      <xsl:text>recursive:&#xa;: </xsl:text>
       <xsl:value-of select="@recursive"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@recurring">
-      <xsl:text>recurring: `</xsl:text>
+      <xsl:text>recurring:&#xa;: </xsl:text>
       <xsl:value-of select="@recurring"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@minver">
-      <xsl:text>minver: `</xsl:text>
+      <xsl:text>minver:&#xa;: </xsl:text>
       <xsl:value-of select="@minver"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:if test="@maxver">
-      <xsl:text>maxver: `</xsl:text>
+      <xsl:text>maxver:&#xa;: </xsl:text>
       <xsl:value-of select="@maxver"/>
-      <xsl:text>`&#xa;&#xa;</xsl:text>
+      <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:if>
     <xsl:for-each select="ebml:documentation">
       <xsl:choose>
@@ -109,7 +109,7 @@
         </xsl:when>
         <xsl:otherwise>documentation</xsl:otherwise>
       </xsl:choose>
-      <xsl:text>: </xsl:text>
+      <xsl:text>:&#xa;: </xsl:text>
       <xsl:value-of select="."/>
       <xsl:text>&#xa;&#xa;</xsl:text>
     </xsl:for-each>


### PR DESCRIPTION
It mostly adds an extra space after the `:` and spaces on new lines.