### PR TITLE
Clean text references in the EBML schema

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -432,7 +432,7 @@ see [@!I-D.ietf-cellar-codec] for more info.</documentation>
   </element>
   <element name="TrackOverlay" path="\Segment\Tracks\TrackEntry\TrackOverlay" id="0x6FAB" type="uinteger">
     <documentation lang="en" purpose="definition">Specify that this track is an overlay track for the Track specified (in the u-integer).
-That means when this track has a gap (see <a href="https://www.matroska.org/technical/elements.html#SilentTracks">SilentTracks</a>)
+That means when this track has a gap, see (#silenttracks-element) on SilentTracks,
 the overlay track **SHOULD** be used instead. The order of multiple TrackOverlay matters, the first one is the one that **SHOULD** be used.
 If not found it **SHOULD** be the second, etc.</documentation>
     <extension webm="0"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -388,7 +388,8 @@ The intepretation of the binary data depends on the BlockAddIDType value and the
     <extension cppname="TrackName"/>
   </element>
   <element name="Language" path="\Segment\Tracks\TrackEntry\Language" id="0x22B59C" type="string" default="eng" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies the language of the track in the <a href="https://www.matroska.org/technical/basics.html#language-codes">Matroska languages form</a>. 
+    <documentation lang="en" purpose="definition">Specifies the language of the track in the Matroska languages form;
+see (#language-codes) on language codes.
 This Element **MUST** be ignored if the LanguageIETF Element is used in the same TrackEntry.</documentation>
     <extension cppname="TrackLanguage"/>
   </element>
@@ -1456,7 +1457,8 @@ If the value is 0 at this level, the tags apply to all the attachments in the Se
     <extension webm="1"/>
   </element>
   <element name="TagLanguage" path="\Segment\Tags\Tag\+SimpleTag\TagLanguage" id="0x447A" type="string" default="und" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specifies the language of the tag specified, in the <a href="https://www.matroska.org/technical/basics.html#language-codes">Matroska languages form</a>.
+    <documentation lang="en" purpose="definition">Specifies the language of the tag specified, in the Matroska languages form;
+see (#language-codes) on language codes.
 This Element **MUST** be ignored if the TagLanguageIETF Element is used within the same SimpleTag Element.</documentation>
     <extension webm="1"/>
     <extension cppname="TagLangue"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1399,7 +1399,7 @@ If empty or not present, then the Tag describes everything in the Segment.</docu
   </element>
   <element name="TargetType" path="\Segment\Tags\Tag\Targets\TargetType" id="0x63CA" type="string" maxOccurs="1">
     <documentation lang="en" purpose="definition">An informational string that can be used to display the logical level of the target like "ALBUM", "TRACK", "MOVIE", "CHAPTER", etc
-(see <a href="https://www.matroska.org/technical/tagging.html#targettypes">TargetType</a>).</documentation>
+; see Section 6.4 of [@!I-D.ietf-cellar-tags].</documentation>
     <restriction>
       <enum value="COLLECTION" label="COLLECTION"/>
       <enum value="EDITION" label="EDITION"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1271,8 +1271,8 @@ If ChapterSegmentEditionUID is undeclared, then no Edition of the linked Segment
     <extension webm="0"/>
   </element>
   <element name="ChapterPhysicalEquiv" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterPhysicalEquiv" id="0x63C3" type="uinteger" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Specify the physical equivalent of this ChapterAtom like "DVD" (60) or "SIDE" (50),
-see <a href="https://www.matroska.org/technical/basics.html#physical-types">complete list of values</a>.</documentation>
+    <documentation lang="en" purpose="definition">Specify the physical equivalent of this ChapterAtom like "DVD" (60) or "SIDE" (50);
+see (#physical-types) for a complete list of values.</documentation>
     <extension webm="0"/>
   </element>
   <element name="ChapterTrack" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterTrack" id="0x8F" type="master" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -401,7 +401,7 @@ If this Element is used, then any Language Elements used in the same TrackEntry 
   </element>
   <element name="CodecID" path="\Segment\Tracks\TrackEntry\CodecID" id="0x86" type="string" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">An ID corresponding to the codec,
-see the <a href="https://www.matroska.org/technical/codec_specs.html">codec page</a> for more info.</documentation>
+see [@!I-D.ietf-cellar-codec] for more info.</documentation>
   </element>
   <element name="CodecPrivate" path="\Segment\Tracks\TrackEntry\CodecPrivate" id="0x63A2" type="binary" maxOccurs="1">
     <documentation lang="en" purpose="definition">Private data only known to the codec.</documentation>
@@ -1356,7 +1356,7 @@ the data correspond to the binary DVD cell pre/post commands; see (#dvd-menu-1) 
   </element>
   <element name="Tags" path="\Segment\Tags" id="0x1254C367" type="master">
     <documentation lang="en" purpose="definition">Element containing metadata describing Tracks, Editions, Chapters, Attachments, or the Segment as a whole.
-A list of valid tags can be found <a href="https://www.matroska.org/technical/tagging.html">here.</a></documentation>
+A list of valid tags can be found in [@!I-D.ietf-cellar-tags].</documentation>
     <extension webm="1"/>
   </element>
   <element name="Tag" path="\Segment\Tags\Tag" id="0x7373" type="master" minOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -916,7 +916,7 @@ The value of this field should be in the -180 to 180 degree range.</documentatio
   </element>
   <element name="TrackOperation" path="\Segment\Tracks\TrackEntry\TrackOperation" id="0xE2" type="master" minver="3" maxOccurs="1">
     <documentation lang="en" purpose="definition">Operation that needs to be applied on tracks to create this virtual track.
-For more details <a href="https://www.matroska.org/technical/notes.html#track-operation">look at the Specification Notes</a> on the subject.</documentation>
+For more details look at (#track-operation).</documentation>
     <extension webm="0"/>
   </element>
   <element name="TrackCombinePlanes" path="\Segment\Tracks\TrackEntry\TrackOperation\TrackCombinePlanes" id="0xE3" type="master" minver="3" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -510,8 +510,7 @@ with the top line of the top field stored first.</documentation>
     <extension cppname="VideoFieldOrder"/>
   </element>
   <element name="StereoMode" path="\Segment\Tracks\TrackEntry\Video\StereoMode" id="0x53B8" type="uinteger" minver="3" default="0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Stereo-3D video mode. There are some more details on
-     <a href="https://www.matroska.org/technical/notes.html#multi-planar-and-3d-videos">3D support in the Specification Notes</a>.</documentation>
+    <documentation lang="en" purpose="definition">Stereo-3D video mode. There are some more details in (#multi-planar-and-3d-videos).</documentation>
     <restriction>
       <enum value="0" label="mono"/>
       <enum value="1" label="side by side (left eye first)"/>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1205,7 +1205,7 @@ If missing the track's DefaultDuration does not apply and no duration informatio
   </element>
   <element name="Chapters" path="\Segment\Chapters" id="0x1043A770" type="master" maxOccurs="1" recurring="1">
     <documentation lang="en" purpose="definition">A system to define basic menus and partition data.
-For more detailed information, look at the <a href="https://www.matroska.org/technical/chapters.html">Chapters Explanation</a>.</documentation>
+For more detailed information, look at the Chapters explanation in (#chapters).</documentation>
     <extension webm="1"/>
   </element>
   <element name="EditionEntry" path="\Segment\Chapters\EditionEntry" id="0x45B9" type="master" minOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -72,7 +72,7 @@ When not specified, it means for all editions found in the Segment.</documentati
     <extension webm="0"/>
   </element>
   <element name="ChapterTranslateCodec" path="\Segment\Info\ChapterTranslate\ChapterTranslateCodec" id="0x69BF" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The <a href="https://www.matroska.org/technical/elements.html#ChapProcessCodecID">chapter codec</a></documentation>
+    <documentation lang="en" purpose="definition">The chapter codec; see (#chapprocesscodecid-element).</documentation>
     <restriction>
       <enum value="0" label="Matroska Script"/>
       <enum value="1" label="DVD-menu"/>
@@ -81,7 +81,7 @@ When not specified, it means for all editions found in the Segment.</documentati
   </element>
   <element name="ChapterTranslateID" path="\Segment\Info\ChapterTranslate\ChapterTranslateID" id="0x69A5" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The binary value used to represent this Segment in the chapter codec data.
-The format depends on the <a href="https://www.matroska.org/technical/chapters.html#ChapProcessCodecID">ChapProcessCodecID</a> used.</documentation>
+The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-element).</documentation>
     <extension webm="0"/>
   </element>
   <element name="TimestampScale" path="\Segment\Info\TimestampScale" id="0x2AD7B1" type="uinteger" range="not 0" default="1000000" minOccurs="1" maxOccurs="1">
@@ -457,7 +457,7 @@ it means for all editions found in the Segment.</documentation>
     <extension webm="0"/>
   </element>
   <element name="TrackTranslateCodec" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateCodec" id="0x66BF" type="uinteger" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The <a href="https://www.matroska.org/technical/elements.html#ChapProcessCodecID">chapter codec</a>.</documentation>
+    <documentation lang="en" purpose="definition">The chapter codec; see (#chapprocesscodecid-element).</documentation>
     <restriction>
       <enum value="0" label="Matroska Script"/>
       <enum value="1" label="DVD-menu"/>
@@ -466,7 +466,7 @@ it means for all editions found in the Segment.</documentation>
   </element>
   <element name="TrackTranslateTrackID" path="\Segment\Tracks\TrackEntry\TrackTranslate\TrackTranslateTrackID" id="0x66A5" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">The binary value used to represent this track in the chapter codec data.
-The format depends on the <a href="https://www.matroska.org/technical/elements.html#ChapProcessCodecID">ChapProcessCodecID</a> used.</documentation>
+The format depends on the ChapProcessCodecID used; see (#chapprocesscodecid-element).</documentation>
     <extension webm="0"/>
   </element>
   <element name="Video" path="\Segment\Tracks\TrackEntry\Video" id="0xE0" type="master" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -352,19 +352,19 @@ This can be used to adjust the playback offset of a track.</documentation>
     <extension webm="0"/>
   </element>
   <element name="MaxBlockAdditionID" path="\Segment\Tracks\TrackEntry\MaxBlockAdditionID" id="0x55EE" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The maximum value of <a href="https://www.matroska.org/technical/elements.html#BlockAddID">BlockAddID</a>.
-A value 0 means there is no <a href="https://www.matroska.org/technical/elements.html#BlockAdditions">BlockAdditions</a> for this track.</documentation>
+    <documentation lang="en" purpose="definition">The maximum value of BlockAddID ((#blockaddid-element)).
+A value 0 means there is no BlockAdditions ((#blockadditions-element)) for this track.</documentation>
     <extension webm="0"/>
   </element>
   <element name="BlockAdditionMapping" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping" id="0x41E4" type="master" minver="4">
-    <documentation lang="en" purpose="definition">Contains elements that extend the track format, by adding content either to each frame
-(with <a href="https://www.matroska.org/technical/specs/elements.html#BlockAddID">BlockAddID</a>) or to the track as a whole
-(with <a href="https://www.matroska.org/technical/specs/elements.html#BlockAddIDExtraData">BlockAddIDExtraData</a>)</documentation>
+    <documentation lang="en" purpose="definition">Contains elements that extend the track format, by adding content either to each frame,
+with BlockAddID ((#blockaddid-element)), or to the track as a whole
+with BlockAddIDExtraData.</documentation>
     <extension webm="0"/>
   </element>
   <element name="BlockAddIDValue" path="\Segment\Tracks\TrackEntry\BlockAdditionMapping\BlockAddIDValue" id="0x41F0" type="uinteger" maxOccurs="1" minver="4" range=">=2">
     <documentation lang="en" purpose="definition">If the track format extension needs content beside frames, 
-the value refers to the <a href="https://www.matroska.org/technical/specs/elements.html#BlockAddID">BlockAddID</a> value being described.
+the value refers to the BlockAddID ((#blockaddid-element)), value being described.
 To keep MaxBlockAdditionID as low as possible, small values **SHOULD** be used.</documentation>
     <extension webm="0"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1217,7 +1217,7 @@ For more detailed information, look at the <a href="https://www.matroska.org/tec
   </element>
   <element name="EditionFlagHidden" path="\Segment\Chapters\EditionEntry\EditionFlagHidden" id="0x45BD" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">If an edition is hidden (1), it **SHOULD NOT** be available to the user interface
-(but still to Control Tracks; see <a href="https://www.matroska.org/technical/chapters.html#flags">flag notes</a>). (1 bit)</documentation>
+(but still to Control Tracks; see (#chapter-flags) on Chapter flags). (1 bit)</documentation>
     <extension webm="0"/>
   </element>
   <element name="EditionFlagDefault" path="\Segment\Chapters\EditionEntry\EditionFlagDefault" id="0x45DB" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
@@ -1251,12 +1251,12 @@ Use for <a href="https://w3c.github.io/webvtt/#webvtt-cue-identifier">WebVTT cue
   </element>
   <element name="ChapterFlagHidden" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagHidden" id="0x98" type="uinteger" range="0-1" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">If a chapter is hidden (1), it **SHOULD NOT** be available to the user interface
-(but still to Control Tracks; see <a href="https://www.matroska.org/technical/chapters.html#flags">flag notes</a>). (1 bit)</documentation>
+(but still to Control Tracks; see (#chapter-flags) on Chapter flags). (1 bit)</documentation>
     <extension webm="0"/>
   </element>
   <element name="ChapterFlagEnabled" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterFlagEnabled" id="0x4598" type="uinteger" range="0-1" default="1" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Specify whether the chapter is enabled. It can be enabled/disabled by a Control Track.
-When disabled, the movie **SHOULD** skip all the content between the TimeStart and TimeEnd of this chapter (see <a href="https://www.matroska.org/technical/chapters.html#flags">flag notes</a>). (1 bit)</documentation>
+When disabled, the movie **SHOULD** skip all the content between the TimeStart and TimeEnd of this chapter; see (#chapter-flags) on Chapter flags. (1 bit)</documentation>
     <extension webm="0"/>
   </element>
   <element name="ChapterSegmentUID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapterSegmentUID" id="0x6E67" type="binary" range="&gt;0" length="16" maxOccurs="1">

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -335,8 +335,8 @@ If set to 0, the reference pseudo-cache system is not used.</documentation>
     <extension cppname="TrackDefaultDuration"/>
   </element>
   <element name="DefaultDecodedFieldDuration" path="\Segment\Tracks\TrackEntry\DefaultDecodedFieldDuration" id="0x234E7A" type="uinteger" minver="4" range="not 0" maxOccurs="1">
-    <documentation lang="en" purpose="definition">The period in nanoseconds (not scaled by TimestampScale) between two successive fields at the output of the decoding process
-(see <a href="https://www.matroska.org/technical/notes.html#defaultdecodedfieldduration">the notes</a>)</documentation>
+    <documentation lang="en" purpose="definition">The period in nanoseconds (not scaled by TimestampScale) between two successive fields at the output of the decoding process,
+see (#defaultdecodedfieldduration) for more information</documentation>
     <extension webm="0"/>
     <extension cppname="TrackDefaultDecodedFieldDuration"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -139,8 +139,8 @@ It might help to resynchronise offset on damaged streams.</documentation>
     <extension cppname="ClusterPrevSize"/>
   </element>
   <element name="SimpleBlock" path="\Segment\Cluster\SimpleBlock" id="0xA3" type="binary" minver="2">
-    <documentation lang="en" purpose="definition">Similar to <a href="https://www.matroska.org/technical/basics.html#block-structure">Block</a> but without all the extra information,
-mostly used to reduced overhead when no extra feature is needed. (see <a href="https://www.matroska.org/technical/basics.html#simpleblock-structure">SimpleBlock Structure</a>)</documentation>
+    <documentation lang="en" purpose="definition">Similar to Block, see (#block-structure), but without all the extra information,
+mostly used to reduced overhead when no extra feature is needed; see (#simpleblock-structure) on SimpleBlock Structure.</documentation>
     <extension webm="1"/>
     <extension divx="1"/>
   </element>
@@ -148,12 +148,12 @@ mostly used to reduced overhead when no extra feature is needed. (see <a href="h
     <documentation lang="en" purpose="definition">Basic container of information containing a single Block and information specific to that Block.</documentation>
   </element>
   <element name="Block" path="\Segment\Cluster\BlockGroup\Block" id="0xA1" type="binary" minOccurs="1" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Block containing the actual data to be rendered and a timestamp relative to the Cluster Timestamp.
-(see <a href="https://www.matroska.org/technical/basics.html#block-structure">Block Structure</a>)</documentation>
+    <documentation lang="en" purpose="definition">Block containing the actual data to be rendered and a timestamp relative to the Cluster Timestamp;
+see (#block-structure) on Block Structure.</documentation>
   </element>
   <element name="BlockVirtual" path="\Segment\Cluster\BlockGroup\BlockVirtual" id="0xA2" type="binary" minver="0" maxver="0" maxOccurs="1">
     <documentation lang="en" purpose="definition">A Block with no data. It **MUST** be stored in the stream at the place the real Block would be in display order.
-(see <a href="https://www.matroska.org/technical/elements.html#BlockVirtual">Block Virtual</a>)</documentation>
+</documentation>
     <extension webm="0"/>
   </element>
   <element name="BlockAdditions" path="\Segment\Cluster\BlockGroup\BlockAdditions" id="0x75A1" type="master" maxOccurs="1">
@@ -267,7 +267,7 @@ Being able to interpret this Element is not **REQUIRED** for playback.</document
     <extension divx="1"/>
   </element>
   <element name="EncryptedBlock" path="\Segment\Cluster\EncryptedBlock" id="0xAF" type="binary" minver="0" maxver="0">
-    <documentation lang="en" purpose="definition">Similar to <a href="https://www.matroska.org/technical/basics.html#simpleblock-structure">SimpleBlock</a>
+    <documentation lang="en" purpose="definition">Similar to SimpleBlock, see (#simpleblock-structure),
 but the data inside the Block are Transformed (encrypt and/or signed).</documentation>
     <extension webm="0"/>
   </element>

--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1320,14 +1320,14 @@ This Element **MUST** be ignored if the ChapLanguageIETF Element is used within 
   </element>
   <element name="ChapProcessCodecID" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessCodecID" id="0x6955" type="uinteger" default="0" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains the type of the codec used for the processing. 
-A value of 0 means native Matroska processing (to be defined), a value of 1 means the <a href="https://www.matroska.org/technical/chapters.html#dvd">DVD</a> command set is used. 
+A value of 0 means native Matroska processing (to be defined), a value of 1 means the DVD command set is used; see (#dvd-menu-1) on DVD menus. 
 More codec IDs can be added later.</documentation>
     <extension webm="0"/>
     <extension cppname="ChapterProcessCodecID"/>
   </element>
   <element name="ChapProcessPrivate" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessPrivate" id="0x450D" type="binary" maxOccurs="1">
     <documentation lang="en" purpose="definition">Some optional data attached to the ChapProcessCodecID information. 
-    <a href="https://www.matroska.org/technical/chapters.html#dvd">For ChapProcessCodecID = 1</a>, it is the "DVD level" equivalent.</documentation>
+    For ChapProcessCodecID = 1, it is the "DVD level" equivalent; see (#dvd-menu-1) on DVD menus.</documentation>
     <extension webm="0"/>
     <extension cppname="ChapterProcessPrivate"/>
   </element>
@@ -1348,8 +1348,8 @@ More codec IDs can be added later.</documentation>
   </element>
   <element name="ChapProcessData" path="\Segment\Chapters\EditionEntry\+ChapterAtom\ChapProcess\ChapProcessCommand\ChapProcessData" id="0x6933" type="binary" minOccurs="1" maxOccurs="1">
     <documentation lang="en" purpose="definition">Contains the command information.
-The data **SHOULD** be interpreted depending on the ChapProcessCodecID value. <a href="https://www.matroska.org/technical/chapters.html#dvd">For ChapProcessCodecID = 1</a>,
-the data correspond to the binary DVD cell pre/post commands.</documentation>
+The data **SHOULD** be interpreted depending on the ChapProcessCodecID value. For ChapProcessCodecID = 1,
+the data correspond to the binary DVD cell pre/post commands; see (#dvd-menu-1) on DVD menus.</documentation>
     <extension webm="0"/>
     <extension cppname="ChapterProcessData"/>
   </element>


### PR DESCRIPTION
It may make the rendered website look funny. Some additional scripting may be needed there.