### PR TITLE
Added AVS2 video codec mapping

### DIFF
--- a/codec_specs.md
+++ b/codec_specs.md
@@ -266,9 +266,9 @@ Initialization: The `Private Data` contains a `HEVCDecoderConfigurationRecord` s
 
 Codec ID: V_AVS2
 
-Codec Name: AVS2-P2/IEEE 1857.4
+Codec Name: AVS2-P2/IEEE.1857.4
 
-Description: Individual pictures of AVS2-P2 stored as described in the second part of IEEE 1857.4.
+Description: Individual pictures of AVS2-P2 stored as described in the second part of IEEE.1857.4.
 
 Initialization: none.
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -268,7 +268,7 @@ Codec ID: V_AVS2
 
 Codec Name: AVS2-P2/IEEE.1857.4
 
-Description: Individual pictures of AVS2-P2 stored as described in the second part of [@!IEEE.1857-4].
+Description: Individual pictures of AVS2-P2 stored as described in the second part of [@!IEEE.1857].
 
 Initialization: none.
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -268,7 +268,7 @@ Codec ID: V_AVS2
 
 Codec Name: AVS2-P2/IEEE.1857.4
 
-Description: Individual pictures of AVS2-P2 stored as described in the second part of [@!IEEE.1857].
+Description: Individual pictures of AVS2-P2 stored as described in the second part of [@!IEEE.1857-4].
 
 Initialization: none.
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -268,7 +268,7 @@ Codec ID: V_AVS2
 
 Codec Name: AVS2-P2/IEEE.1857.4
 
-Description: Individual pictures of AVS2-P2 stored as described in the second part of IEEE.1857.4.
+Description: Individual pictures of AVS2-P2 stored as described in the second part of [@!IEEE.1857-4].
 
 Initialization: none.
 

--- a/codec_specs.md
+++ b/codec_specs.md
@@ -262,6 +262,16 @@ Description: Individual pictures (which could be a frame, a field, or 2 fields h
 
 Initialization: The `Private Data` contains a `HEVCDecoderConfigurationRecord` structure as defined in [@!ISO.14496-15].
 
+### V_AVS2
+
+Codec ID: V_AVS2
+
+Codec Name: AVS2-P2/IEEE 1857.4
+
+Description: Individual pictures of AVS2-P2 stored as described in the second part of IEEE 1857.4.
+
+Initialization: none.
+
 ### V_REAL/RV10
 
 Codec ID: V_REAL/RV10

--- a/rfc_backmatter_codec.md
+++ b/rfc_backmatter_codec.md
@@ -11,6 +11,16 @@
   </front>
 </reference>
 
+<reference anchor="IEEE.1857-4" target="https://standards.ieee.org/standard/1857_4-2018.html">
+  <front>
+    <title>IEEE Standard for Second-Generation IEEE 1857 Video Coding</title>
+    <author>
+      <organization>IEEE</organization>
+    </author>
+    <date year="2018" month="October" day="23"/>
+  </front>
+</reference>
+
 <reference anchor="IEEE.754" target="https://standards.ieee.org/standard/754-2019.html">
   <front>
     <title>IEEE Standard for Binary Floating-Point Arithmetic</title>


### PR DESCRIPTION
avs2 (IEEE 1857.4) video codec mapping

**Standard document**: 
           1857.4-2018 - IEEE Standard for Second-Generation IEEE 1857 Video Coding (https://ieeexplore.ieee.org/document/8821610)

**Encoding tool**:
        Ffmpeg with avs2 enabled: https://github.com/xatabhk/FFmpeg-avs2-avs3/releases/tag/n4.4-dev-avs3
        Command line: 
```
             ffmpeg -i xxxx.mp4 -vcodec avs2 -acodec copy xxxx_avs2.mkv
             ffmpeg -i xxxx.mp4 -vcodec avs2 -speed_level 4 -acodec copy xxxx_avs2.mkv`
```
**Players**:
  (1)	Ffmpeg with avs2 enabled: (https://github.com/xatabhk/FFmpeg-avs2-avs3/releases/tag/n4.4-dev-avs3):
        Command line:
```
             ffplay xxxx_avs2.mkv`
```
  (2)	VLC 3.0.x with avs2 enabled: https://github.com/xatabhk/vlc-3.0-avs2-avs3/releases
  (3)	Mpc-hc 1.9.x with avs2 enabled: https://gitee.com/zhengtianbo/cavs-avs2-avs3_decoder_added_to_mpc_hc/releases

**Avs2-MKV samples**:
        https://github.com/xatabhk/avs2-avs3-video-samples
