### PR TITLE
Add support for zstd content compression

### DIFF
--- a/ebml_matroska.xml
+++ b/ebml_matroska.xml
@@ -1027,12 +1027,14 @@ Each block **MUST** be decompressable even if no previous block is available in 
       <enum value="1" label="bzlib"/>
       <enum value="2" label="lzo1x"/>
       <enum value="3" label="Header Stripping"/>
+      <enum value="4" label="zstd"/>
     </restriction>
     <extension webm="0"/>
   </element>
   <element name="ContentCompSettings" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentCompression\ContentCompSettings" id="0x4255" type="binary" maxOccurs="1">
-    <documentation lang="en" purpose="definition">Settings that might be needed by the decompressor. For Header Stripping (`ContentCompAlgo`=3),
-the bytes that were removed from the beginning of each frames of the track.</documentation>
+    <documentation lang="en" purpose="definition">Settings that might be needed by the decompressor.
+For Header Stripping (`ContentCompAlgo`=3), the bytes that were removed from the beginning of each frames of the track.
+For zstd (`ContentCompAlgo`=4), an optional dictionary used to improve compression efficiency.</documentation>
     <extension webm="0"/>
   </element>
   <element name="ContentEncryption" path="\Segment\Tracks\TrackEntry\ContentEncodings\ContentEncoding\ContentEncryption" id="0x5035" type="master" maxOccurs="1">


### PR DESCRIPTION
The other compression schemes supported in Matroska suffer from having to be applied on a per-packet level, with no global state. This means that they can't exploit any of the redundancy between packets, and any huffman tables or other configuration has to be duplicated in every packet. This severely limits the attainable compression efficiency to approximately the level attained by zlib, which has led to the other algorithms receiving very little adoption by content authors, and little support from tool vendors.

The zstd library, on the other hand, supports generating a dictionary from a large number of small inputs (e.g. packets), and using that dictionary to compress similar inputs more efficiently. This improves performance on subtitle inputs dramatically.

Muxing tools can either scan the input and pass its packets into zstd before muxing an individual file, or provide an auxiliary tool that generates a dictionary from the packets of one or more input files, then saves the result to a file that can be reused when muxing tracks with similar content.