### PR TITLE
Remove WebM specific text

### DIFF
--- a/matroska_schema_section_header.md
+++ b/matroska_schema_section_header.md
@@ -1,13 +1,4 @@
 
-# Matroska Additions to Schema Element Attributes
-
-In addition to the EBML Schema definition provided by the EBML Specification,
-Matroska adds the following additional attributes:
-
-| attribute name | required | definition |
-|:---------------|:---------|:-----------|
-| webm           | No       | A boolean to express if the Matroska Element is also supported within version 2 of the `webm` specification. Please consider the [webm specification](http://www.webmproject.org/docs/container/) as the authoritative on `webm`. |
-
 # Matroska Schema
 
 This specification includes an `EBML Schema`, which defines the Elements and structure


### PR DESCRIPTION
We are not defining WebM in this document. That extension is stripped from the EBML Schema to produce a Matroska-only version.
There is no WebM specific element, unlike the DivX extension.