### PR TITLE
Use references for links in the tags documentation

### DIFF
--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -326,7 +326,7 @@ excluding the "ISRC" prefix and including hyphens.</description>
 This holds the same information as the "MCDI" in [@!ID3v2].</description>
     </tag>
     <tag name="ISBN" class="Identifiers" type="UTF-8">
-      <description lang="en">[International Standard Book Number](https://www.isbn-international.org/)</description>
+      <description lang="en">International Standard Book Number [@!ISBN].</description>
     </tag>
     <tag name="BARCODE" class="Identifiers" type="UTF-8">
       <description lang="en">[EAN-13](https://www.gs1.org/standards/barcodes/ean-upc) (European Article Numbering)

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -311,11 +311,11 @@ The majority of the contemporary rock and pop music you hear on the radio these 
 the same tone as the musical piece (e.g., "441.34" in Hertz). The default value is 440.0 Hz.</description>
     </tag>
     <tag name="REPLAYGAIN_GAIN" class="Technical Information" type="binary">
-      <description lang="en">The gain to apply to reach 89dB SPL on playback. This is based on the [Replay Gain standard](http://www.replaygain.org/).
+      <description lang="en">The gain to apply to reach 89dB SPL on playback. This is based on the [@!ReplayGain] standard.
 Note that ReplayGain information can be found at all TargetType levels (track, album, etc).</description>
     </tag>
     <tag name="REPLAYGAIN_PEAK" class="Technical Information" type="binary">
-      <description lang="en">The maximum absolute peak value of the item. This is based on the [Replay Gain standard](http://www.replaygain.org/).</description>
+      <description lang="en">The maximum absolute peak value of the item. This is based on the [@!ReplayGain] standard.</description>
     </tag>
     <tag name="ISRC" class="Identifiers" type="UTF-8">
       <description lang="en">The [International Standard Recording Code](http://www.ifpi.org/isrc/isrc_handbook.html#Heading198),

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -329,8 +329,7 @@ This holds the same information as the "MCDI" in [@!ID3v2].</description>
       <description lang="en">International Standard Book Number [@!ISBN].</description>
     </tag>
     <tag name="BARCODE" class="Identifiers" type="UTF-8">
-      <description lang="en">[EAN-13](https://www.gs1.org/standards/barcodes/ean-upc) (European Article Numbering)
-or [UPC-A](http://www.uc-council.org/) (Universal Product Code) bar code identifier</description>
+      <description lang="en">European Article Numbering EAN-13 barcode defined in [@!GS1] General Specifications.</description>
     </tag>
     <tag name="CATALOG_NUMBER" class="Identifiers" type="UTF-8">
       <description lang="en">A label-specific string used to identify the release -- for example, TIC 01.</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -254,7 +254,7 @@ an age in other countries or a URI defining a logo).</description>
     </tag>
     <tag name="RECORDING_LOCATION" class="Spacial Information" type="UTF-8">
       <description lang="en">The location where the item was recorded. The countries corresponding to the string,
-same 2 octets as in [Internet domains](https://www.iana.org/whois), or possibly [ISO-3166](https://www.iso.org/iso-3166-country-codes.html).
+same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city. For example,
 "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state
@@ -262,7 +262,7 @@ is unknown, but you want to store the city, simply leave a space between the two
     </tag>
     <tag name="COMPOSITION_LOCATION" class="Spacial Information" type="UTF-8">
       <description lang="en">Location that the item was originally designed/written. The countries corresponding to the string,
-same 2 octets as in [Internet domains](https://www.iana.org/whois), or possibly [ISO-3166](https://www.iso.org/iso-3166-country-codes.html).
+same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.
 This code is followed by a comma, then more detailed information such as state/province, another comma, and then city.
 For example, "US, Texas, Austin". This will allow for easy sorting. It is okay to only store the country, or the country and the state/province.
 More detailed information can be added after the city through the use of additional commas. In cases where the province/state is unknown,
@@ -270,8 +270,8 @@ but you want to store the city, simply leave a space between the two commas. For
     </tag>
     <tag name="COMPOSER_NATIONALITY" class="Spacial Information" type="UTF-8">
       <description lang="en">Nationality of the main composer of the item, mostly for classical music.
-The countries corresponding to the string, same 2 octets as in [Internet domains](https://www.iana.org/whois),
-or possibly [ISO-3166](https://www.iso.org/iso-3166-country-codes.html).</description>
+The countries corresponding to the string, 
+same 2 octets country-codes as in Internet domains [@!IANADomains] based on [@!ISO3166-1] alpha-2 codes.</description>
     </tag>
     <tag name="COMMENT" class="Personal" type="UTF-8">
       <description lang="en">Any comment related to the content.</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -345,7 +345,7 @@ This holds the same information as the "MCDI" in [@!ID3v2].</description>
       <description lang="en">Internet Movie Database [@!IMDb] identifier. "tt" followed by at least 7 digits for Movies, TV Shows, and Episodes.</description>
     </tag>
     <tag name="TMDB" class="Identifiers" type="UTF-8">
-      <description lang="en">[The Movie Database (TMDb)](https://www.themoviedb.org/) identifier. The variable length digits string **MUST** be prefixed with either "movie/" or "tv/".</description>
+      <description lang="en">The Movie DB "movie_id" or "tv_id" identifier for movies/TV shows [@!MovieDB]. The variable length digits string **MUST** be prefixed with either "movie/" or "tv/".</description>
     </tag>
     <tag name="TVDB" class="Identifiers" type="UTF-8">
       <description lang="en">[The TV Database (TheTVDB)](https://www.thetvdb.com/) identifier. Variable length all-digits string identifying a TV Show.</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -339,7 +339,7 @@ This holds the same information as the "MCDI" in [@!ID3v2].</description>
 0xxxx on CDs medias or covers (only the number is stored).</description>
     </tag>
     <tag name="LCCN" class="Identifiers" type="UTF-8">
-      <description lang="en">[Library of Congress Control Number](https://www.loc.gov/marc/lccn.html)</description>
+      <description lang="en">Library of Congress Control Number [@!LCCN].</description>
     </tag>
     <tag name="IMDB" class="Identifiers" type="UTF-8">
       <description lang="en">[Internet Movie Database (IMDb)](https://www.imdb.com/) identifier. "tt" followed by at least 7 digits for Movies, TV Shows, and Episodes.</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -318,7 +318,7 @@ Note that ReplayGain information can be found at all TargetType levels (track, a
       <description lang="en">The maximum absolute peak value of the item. This is based on the [@!ReplayGain] standard.</description>
     </tag>
     <tag name="ISRC" class="Identifiers" type="UTF-8">
-      <description lang="en">The [International Standard Recording Code](http://www.ifpi.org/isrc/isrc_handbook.html#Heading198),
+      <description lang="en">The International Standard Recording Code [@!ISRC],
 excluding the "ISRC" prefix and including hyphens.</description>
     </tag>
     <tag name="MCDI" class="Identifiers" type="binary">

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -365,7 +365,7 @@ or [UPC-A](http://www.uc-council.org/) (Universal Product Code) bar code identif
 no letters or symbols other than ".". For instance, you would store "15.59" instead of "$15.59USD".</description>
     </tag>
     <tag name="PURCHASE_CURRENCY" class="Commercial" type="UTF-8">
-      <description lang="en">The currency type used to pay for the entity. Use [ISO-4217](https://www.xe.com/iso4217.php) for the 3 letter currency code.</description>
+      <description lang="en">The currency type used to pay for the entity. Use [@!ISO4217] for the 3 letter alphabetic code.</description>
     </tag>
     <tag name="COPYRIGHT" class="Legal" type="UTF-8">
       <description lang="en">The copyright information as per the copyright holder. This is akin to the "TCOP" tag in [@!ID3v2].</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -348,7 +348,7 @@ This holds the same information as the "MCDI" in [@!ID3v2].</description>
       <description lang="en">The Movie DB "movie_id" or "tv_id" identifier for movies/TV shows [@!MovieDB]. The variable length digits string **MUST** be prefixed with either "movie/" or "tv/".</description>
     </tag>
     <tag name="TVDB" class="Identifiers" type="UTF-8">
-      <description lang="en">[The TV Database (TheTVDB)](https://www.thetvdb.com/) identifier. Variable length all-digits string identifying a TV Show.</description>
+      <description lang="en">The TV Database "Series ID" or "Episode ID" identifier for TV shows [@!TheTVDB]. Variable length all-digits string identifying a TV Show.</description>
     </tag>
     <tag name="PURCHASE_ITEM" class="Commercial" type="UTF-8">
       <description lang="en">URL to purchase this file. This is akin to the "WPAY" tag in [@!ID3v2].</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -109,14 +109,14 @@ in editing the subtitle track for more consistency.</description>
       <description lang="en">Conductor/performer refinement. This is akin to the "TPE3" tag in [@!ID3v2].</description>
     </tag>
     <tag name="DIRECTOR" class="Entities" type="UTF-8">
-      <description lang="en">This is akin to the [IART tag in RIFF][@RIFF.tags].</description>
+      <description lang="en">This is akin to the "IART" tag [@?RIFF.tags].</description>
     </tag>
     <tag name="ASSISTANT_DIRECTOR" class="Entities" type="UTF-8">
       <description lang="en">The name of the assistant director.</description>
     </tag>
     <tag name="DIRECTOR_OF_PHOTOGRAPHY" class="Entities" type="UTF-8">
       <description lang="en">The name of the director of photography, also known as cinematographer.
-This is akin to the ICNM tag in Extended RIFF.</description>
+This is akin to the "ICNM" tag in [@?RIFF.tags].</description>
     </tag>
     <tag name="SOUND_ENGINEER" class="Entities" type="UTF-8">
       <description lang="en">The name of the sound engineer or sound recordist.</description>
@@ -148,10 +148,10 @@ This **SHOULD** be a sub-tag of an `ACTOR` tag in order not to cause ambiguities
       <description lang="en">The author of the screenplay or scenario (used for movies and TV shows).</description>
     </tag>
     <tag name="EDITED_BY" class="Entities" type="UTF-8">
-      <description lang="en">This is akin to the IEDT tag in Extended RIFF.</description>
+      <description lang="en">This is akin to the "IEDT" tag in [@?RIFF.tags].</description>
     </tag>
     <tag name="PRODUCER" class="Entities" type="UTF-8">
-      <description lang="en">Produced by. This is akin to the IPRO tag in Extended RIFF.</description>
+      <description lang="en">Produced by. This is akin to the "IPRO" tag in [@?RIFF.tags].</description>
     </tag>
     <tag name="COPRODUCER" class="Entities" type="UTF-8">
       <description lang="en">The name of a co-producer.</description>
@@ -160,7 +160,7 @@ This **SHOULD** be a sub-tag of an `ACTOR` tag in order not to cause ambiguities
       <description lang="en">The name of an executive producer.</description>
     </tag>
     <tag name="DISTRIBUTED_BY" class="Entities" type="UTF-8">
-      <description lang="en">This is akin to the IDST tag in Extended RIFF.</description>
+      <description lang="en">This is akin to the "IDST" tag in [@?RIFF.tags].</description>
     </tag>
     <tag name="MASTERED_BY" class="Entities" type="UTF-8">
       <description lang="en">The engineer who mastered the content for a physical medium or
@@ -177,7 +177,7 @@ for digital distribution.</description>
 the "TPE4" tag in [@!ID3v2].</description>
     </tag>
     <tag name="PRODUCTION_STUDIO" class="Entities" type="UTF-8">
-      <description lang="en">This is akin to the ISTD tag in Extended RIFF.</description>
+      <description lang="en">This is akin to the "ISTD" tag in [@?RIFF.tags].</description>
     </tag>
     <tag name="THANKS_TO" class="Entities" type="UTF-8">
       <description lang="en">A very general tag for everyone else that wants to be listed.</description>
@@ -244,7 +244,7 @@ an age in other countries or a URI defining a logo).</description>
       <description lang="en">The time that the tags were done for this item. This is akin to the "TDTG" tag in [@!ID3v2].</description>
     </tag>
     <tag name="DATE_DIGITIZED" class="Temporal Information" type="UTF-8">
-      <description lang="en">The time that the item was transferred to a digital medium. This is akin to the IDIT tag in RIFF.</description>
+      <description lang="en">The time that the item was transferred to a digital medium. This is akin to the "IDIT" tag in [@?RIFF.tags].</description>
     </tag>
     <tag name="DATE_WRITTEN" class="Temporal Information" type="UTF-8">
       <description lang="en">The time that the writing of the music/script began.</description>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -49,7 +49,7 @@ the track number of an audio CD)</description>
     </tag>
     <tag name="TITLE" class="Titles" type="UTF-8">
       <description lang="en">The title of this item. For example, for music you might label this "Canon in D",
-or for video's audio track you might use "English 5.1" This is akin to the TIT2 tag in ID3.</description>
+or for video's audio track you might use "English 5.1" This is akin to the "TIT2" tag in [@!ID3v2].</description>
     </tag>
     <tag name="SUBTITLE" class="Titles" type="UTF-8">
       <description lang="en">Sub Title of the entity.</description>
@@ -83,16 +83,16 @@ It can be useful for a recording label.</description>
     </tag>
     <tag name="ARTIST" class="Entities" type="UTF-8">
       <description lang="en">A person or band/collective generally considered responsible for the work.
-This is akin to the [TPE1 tag in ID3](http://id3.org/id3v2.3.0#TPE1).</description>
+This is akin to the "TPE1" tag in [@!ID3v2].</description>
     </tag>
     <tag name="LEAD_PERFORMER" class="Entities" type="UTF-8">
       <description lang="en">Lead Performer/Soloist(s). This can sometimes be the same as ARTIST.</description>
     </tag>
     <tag name="ACCOMPANIMENT" class="Entities" type="UTF-8">
-      <description lang="en">Band/orchestra/accompaniment/musician. This is akin to the [TPE2 tag in ID3](http://id3.org/id3v2.3.0#TPE2).</description>
+      <description lang="en">Band/orchestra/accompaniment/musician. This is akin to the "TPE2" tag in [@!ID3v2].</description>
     </tag>
     <tag name="COMPOSER" class="Entities" type="UTF-8">
-      <description lang="en">The name of the composer of this item. This is akin to the [TCOM tag in ID3](http://id3.org/id3v2.3.0#TCOM).</description>
+      <description lang="en">The name of the composer of this item. This is akin to the "TCOM" tag in [@!ID3v2].</description>
     </tag>
     <tag name="ARRANGER" class="Entities" type="UTF-8">
       <description lang="en">The person who arranged the piece, e.g., Ravel.</description>
@@ -103,10 +103,10 @@ or as a doublon to a subtitle track). Editing this value, when subtitles are fou
 in editing the subtitle track for more consistency.</description>
     </tag>
     <tag name="LYRICIST" class="Entities" type="UTF-8">
-      <description lang="en">The person who wrote the lyrics for a musical item. This is akin to the [TEXT](http://id3.org/id3v2.3.0#TEXT) tag in ID3.</description>
+      <description lang="en">The person who wrote the lyrics for a musical item. This is akin to the "TEXT" tag in [@!ID3v2].</description>
     </tag>
     <tag name="CONDUCTOR" class="Entities" type="UTF-8">
-      <description lang="en">Conductor/performer refinement. This is akin to the [TPE3](http://id3.org/id3v2.3.0#TPE3).</description>
+      <description lang="en">Conductor/performer refinement. This is akin to the "TPE3" tag in [@!ID3v2].</description>
     </tag>
     <tag name="DIRECTOR" class="Entities" type="UTF-8">
       <description lang="en">This is akin to the [IART tag in RIFF][@RIFF.tags].</description>
@@ -167,14 +167,14 @@ This **SHOULD** be a sub-tag of an `ACTOR` tag in order not to cause ambiguities
 for digital distribution.</description>
     </tag>
     <tag name="ENCODED_BY" class="Entities" type="UTF-8">
-      <description lang="en">This is akin to the [TENC tag](http://id3.org/id3v2.3.0#TENC) in ID3.</description>
+      <description lang="en">This is akin to the "TENC" tag in [@!ID3v2].</description>
     </tag>
     <tag name="MIXED_BY" class="Entities" type="UTF-8">
       <description lang="en">DJ mix by the artist specified</description>
     </tag>
     <tag name="REMIXED_BY" class="Entities" type="UTF-8">
       <description lang="en">Interpreted, remixed, or otherwise modified by. This is akin to
-the [TPE4 tag in ID3](http://id3.org/id3v2.3.0#TPE4).</description>
+the "TPE4" tag in [@!ID3v2].</description>
     </tag>
     <tag name="PRODUCTION_STUDIO" class="Entities" type="UTF-8">
       <description lang="en">This is akin to the ISTD tag in Extended RIFF.</description>
@@ -183,22 +183,22 @@ the [TPE4 tag in ID3](http://id3.org/id3v2.3.0#TPE4).</description>
       <description lang="en">A very general tag for everyone else that wants to be listed.</description>
     </tag>
     <tag name="PUBLISHER" class="Entities" type="UTF-8">
-      <description lang="en">This is akin to the [TPUB tag in ID3](http://id3.org/id3v2.3.0#TPUB).</description>
+      <description lang="en">This is akin to the "TPUB" tag in [@!ID3v2].</description>
     </tag>
     <tag name="LABEL" class="Entities" type="UTF-8">
       <description lang="en">The record label or imprint on the disc.</description>
     </tag>
     <tag name="GENRE" class="Search and Classification" type="UTF-8">
       <description lang="en">The main genre (classical, ambient-house, synthpop, sci-fi, drama, etc).
-The format follows the infamous TCON tag in ID3.</description>
+The format follows the infamous "TCON" tag in [@!ID3v2].</description>
     </tag>
     <tag name="MOOD" class="Search and Classification" type="UTF-8">
       <description lang="en">Intended to reflect the mood of the item with a few keywords, e.g., "Romantic",
-"Sad" or "Uplifting". The format follows that of the TMOO tag in ID3.</description>
+"Sad" or "Uplifting". The format follows that of the "TMOO" tag in [@!ID3v2].</description>
     </tag>
     <tag name="ORIGINAL_MEDIA_TYPE" class="Search and Classification" type="UTF-8">
       <description lang="en">Describes the original type of the media, such as, "DVD", "CD", "computer image,"
-"drawing," "lithograph," and so forth. This is akin to the [TMED tag in ID3](http://id3.org/id3v2.3.0#TMED).</description>
+"drawing," "lithograph," and so forth. This is akin to the "TMED" tag in [@!ID3v2].</description>
     </tag>
     <tag name="CONTENT_TYPE" class="Search and Classification" type="UTF-8">
       <description lang="en">The type of the item. e.g., Documentary, Feature Film, Cartoon, Music Video, Music, Sound FX, ...</description>
@@ -219,7 +219,7 @@ The format follows the infamous TCON tag in ID3.</description>
       <description lang="en">A description of the story line of the item.</description>
     </tag>
     <tag name="INITIAL_KEY" class="Search and Classification" type="UTF-8">
-      <description lang="en">The initial key that a musical track starts in. The format is identical to ID3.</description>
+      <description lang="en">The initial key that a musical track starts in. The format is identical to "TKEY" tag in [@!ID3v2].</description>
     </tag>
     <tag name="PERIOD" class="Search and Classification" type="UTF-8">
       <description lang="en">Describes the period that the piece is from or about. For example, "Renaissance".</description>
@@ -232,16 +232,16 @@ an age in other countries or a URI defining a logo).</description>
       <description lang="en">The [ICRA](http://www.icra.org/) content rating for parental control. (Previously RSACi)</description>
     </tag>
     <tag name="DATE_RELEASED" class="Temporal Information" type="UTF-8">
-      <description lang="en">The time that the item was originally released. This is akin to the TDRL tag in ID3.</description>
+      <description lang="en">The time that the item was originally released. This is akin to the "TDRL" tag in [@!ID3v2].</description>
     </tag>
     <tag name="DATE_RECORDED" class="Temporal Information" type="UTF-8">
-      <description lang="en">The time that the recording began. This is akin to the TDRC tag in ID3.</description>
+      <description lang="en">The time that the recording began. This is akin to the "TDRC" tag in [@!ID3v2].</description>
     </tag>
     <tag name="DATE_ENCODED" class="Temporal Information" type="UTF-8">
-      <description lang="en">The time that the encoding of this item was completed began. This is akin to the TDEN tag in ID3.</description>
+      <description lang="en">The time that the encoding of this item was completed began. This is akin to the "TDEN" tag in [@!ID3v2].</description>
     </tag>
     <tag name="DATE_TAGGED" class="Temporal Information" type="UTF-8">
-      <description lang="en">The time that the tags were done for this item. This is akin to the TDTG tag in ID3.</description>
+      <description lang="en">The time that the tags were done for this item. This is akin to the "TDTG" tag in [@!ID3v2].</description>
     </tag>
     <tag name="DATE_DIGITIZED" class="Temporal Information" type="UTF-8">
       <description lang="en">The time that the item was transferred to a digital medium. This is akin to the IDIT tag in RIFF.</description>
@@ -323,7 +323,7 @@ excluding the "ISRC" prefix and including hyphens.</description>
     </tag>
     <tag name="MCDI" class="Identifiers" type="binary">
       <description lang="en">This is a binary dump of the TOC of the CDROM that this item was taken from.
-This holds the same information as the MCDI in ID3.</description>
+This holds the same information as the "MCDI" in [@!ID3v2].</description>
     </tag>
     <tag name="ISBN" class="Identifiers" type="UTF-8">
       <description lang="en">[International Standard Book Number](https://www.isbn-international.org/)</description>
@@ -352,13 +352,13 @@ or [UPC-A](http://www.uc-council.org/) (Universal Product Code) bar code identif
       <description lang="en">[The TV Database (TheTVDB)](https://www.thetvdb.com/) identifier. Variable length all-digits string identifying a TV Show.</description>
     </tag>
     <tag name="PURCHASE_ITEM" class="Commercial" type="UTF-8">
-      <description lang="en">URL to purchase this file. This is akin to the WPAY tag in ID3.</description>
+      <description lang="en">URL to purchase this file. This is akin to the "WPAY" tag in [@!ID3v2].</description>
     </tag>
     <tag name="PURCHASE_INFO" class="Commercial" type="UTF-8">
-      <description lang="en">Information on where to purchase this album. This is akin to the WCOM tag in ID3.</description>
+      <description lang="en">Information on where to purchase this album. This is akin to the "WCOM" tag in [@!ID3v2].</description>
     </tag>
     <tag name="PURCHASE_OWNER" class="Commercial" type="UTF-8">
-      <description lang="en">Information on the person who purchased the file. This is akin to the [TOWN tag in ID3](http://id3.org/id3v2.3.0#TOWN).</description>
+      <description lang="en">Information on the person who purchased the file. This is akin to the "TOWN" tag in [@!ID3v2].</description>
     </tag>
     <tag name="PURCHASE_PRICE" class="Commercial" type="UTF-8">
       <description lang="en">The amount paid for entity. There **SHOULD** only be a numeric value in here. Only numbers, 
@@ -368,16 +368,16 @@ no letters or symbols other than ".". For instance, you would store "15.59" inst
       <description lang="en">The currency type used to pay for the entity. Use [ISO-4217](https://www.xe.com/iso4217.php) for the 3 letter currency code.</description>
     </tag>
     <tag name="COPYRIGHT" class="Legal" type="UTF-8">
-      <description lang="en">The copyright information as per the copyright holder. This is akin to the TCOP tag in ID3.</description>
+      <description lang="en">The copyright information as per the copyright holder. This is akin to the "TCOP" tag in [@!ID3v2].</description>
     </tag>
     <tag name="PRODUCTION_COPYRIGHT" class="Legal" type="UTF-8">
-      <description lang="en">The copyright information as per the production copyright holder. This is akin to the TPRO tag in ID3.</description>
+      <description lang="en">The copyright information as per the production copyright holder. This is akin to the "TPRO" tag in [@!ID3v2].</description>
     </tag>
     <tag name="LICENSE" class="Legal" type="UTF-8">
       <description lang="en">The license applied to the content (like Creative Commons variants).</description>
     </tag>
     <tag name="TERMS_OF_USE" class="Legal" type="UTF-8">
-      <description lang="en">The terms of use for this item. This is akin to the USER tag in ID3.</description>
+      <description lang="en">The terms of use for this item. This is akin to the "USER" tag in [@!ID3v2].</description>
     </tag>
   </tags>
 </matroska_tagging_registry>

--- a/matroska_tags.xml
+++ b/matroska_tags.xml
@@ -342,7 +342,7 @@ This holds the same information as the "MCDI" in [@!ID3v2].</description>
       <description lang="en">Library of Congress Control Number [@!LCCN].</description>
     </tag>
     <tag name="IMDB" class="Identifiers" type="UTF-8">
-      <description lang="en">[Internet Movie Database (IMDb)](https://www.imdb.com/) identifier. "tt" followed by at least 7 digits for Movies, TV Shows, and Episodes.</description>
+      <description lang="en">Internet Movie Database [@!IMDb] identifier. "tt" followed by at least 7 digits for Movies, TV Shows, and Episodes.</description>
     </tag>
     <tag name="TMDB" class="Identifiers" type="UTF-8">
       <description lang="en">[The Movie Database (TMDb)](https://www.themoviedb.org/) identifier. The variable length digits string **MUST** be prefixed with either "movie/" or "tv/".</description>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -18,6 +18,16 @@
   </front>
 </reference>
 
+<reference anchor="ISBN" target="https://www.isbn-international.org/content/isbn-users-manual">
+  <front>
+    <title>ISBN Users' Manual</title>
+    <author>
+      <organization>International ISBN Agency</organization>
+    </author>
+    <date month="December" year="2017"/>
+  </front>
+</reference>
+
 <reference anchor="ISO3166-1" target="https://www.iso.org/standard/72482.html">
   <front>
     <title>Codes for the representation of names of countries and their subdivisions -- Part 1: Country code</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -29,6 +29,14 @@
   <seriesInfo name="ISO" value="3166-1:2020" />
 </reference>
 
+<reference anchor="ReplayGain" target="http://wiki.hydrogenaud.io/index.php?title=Replay_Gain_specification">
+  <front>
+    <title>ReplayGain 1.0 specification</title>
+     <author fullname='David Robinson'><organization/></author>
+     <date day="10" month="July" year="2001" />
+  </front>
+</reference>
+
 <reference anchor="RIFF.tags" target="https://exiftool.org/TagNames/RIFF.html">
   <front>
     <title>RIFF Tags</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -114,3 +114,13 @@
     </author>
   </front>
 </reference>
+
+<reference anchor="TheTVDB" target="https://www.thetvdb.com/api-information">
+  <front>
+    <title>API documentation</title>
+    <author>
+      <organization>The TVDB</organization>
+    </author>
+  </front>
+</reference>
+

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -29,6 +29,17 @@
   <seriesInfo name="ISO" value="3166-1:2020" />
 </reference>
 
+<reference anchor="ISRC" target="https://www.ifpi.org/wp-content/uploads/2020/08/ISRC_Handbook.pdf">
+  <front>
+    <title>International Standard Recording Code (ISRC) Handbook</title>
+    <author>
+      <organization>IFPI Secretariat</organization>
+    </author>
+    <date year="2009"/>
+  </front>
+  <seriesInfo name="IFPI" value="3rd Edition" />
+</reference>
+
 <reference anchor="ReplayGain" target="http://wiki.hydrogenaud.io/index.php?title=Replay_Gain_specification">
   <front>
     <title>ReplayGain 1.0 specification</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -1,6 +1,13 @@
 
 {backmatter}
 
+<reference anchor="IANADomains" target="https://www.iana.org/domains/root/db">
+  <front>
+    <title>IANA Root Zone Database</title>
+    <author/>
+  </front>
+</reference>
+
 <reference anchor="ID3v2" target="https://id3.org/id3v2.3.0">
   <front>
     <title>ID3 tag version 2.3.0</title>
@@ -9,6 +16,17 @@
      <author fullname='Johan Sundstrom' role='editor'><organization/></author>
      <date day="3" month="February" year="1999" />
   </front>
+</reference>
+
+<reference anchor="ISO3166-1" target="https://www.iso.org/standard/72482.html">
+  <front>
+    <title>Codes for the representation of names of countries and their subdivisions -- Part 1: Country code</title>
+    <author>
+      <organization>International Organization for Standardization</organization>
+    </author>
+    <date month="August" year="2020"/>
+  </front>
+  <seriesInfo name="ISO" value="3166-1:2020" />
 </reference>
 
 <reference anchor="RIFF.tags" target="https://exiftool.org/TagNames/RIFF.html">

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -89,6 +89,15 @@
   </front>
 </reference>
 
+<reference anchor="MovieDB" target="https://developers.themoviedb.org/3/movies/get-movie-details">
+  <front>
+    <title>The Movie Database API</title>
+    <author>
+      <organization>The Movie Database</organization>
+    </author>
+  </front>
+</reference>
+
 <reference anchor="ReplayGain" target="http://wiki.hydrogenaud.io/index.php?title=Replay_Gain_specification">
   <front>
     <title>ReplayGain 1.0 specification</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -11,7 +11,7 @@
   </front>
 </reference>
 
-<reference anchor="RIFF.tags" target="https://sno.phy.queensu.ca/~phil/exiftool/TagNames/RIFF.html">
+<reference anchor="RIFF.tags" target="https://exiftool.org/TagNames/RIFF.html">
   <front>
     <title>RIFF Tags</title>
     <author>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -1,6 +1,16 @@
 
 {backmatter}
 
+<reference anchor="ID3v2" target="https://id3.org/id3v2.3.0">
+  <front>
+    <title>ID3 tag version 2.3.0</title>
+     <author fullname='Martin Nilsson'><organization/></author>
+     <author fullname='Dirk Mahoney' role='editor'><organization/></author>
+     <author fullname='Johan Sundstrom' role='editor'><organization/></author>
+     <date day="3" month="February" year="1999" />
+  </front>
+</reference>
+
 <reference anchor="RIFF.tags" target="https://sno.phy.queensu.ca/~phil/exiftool/TagNames/RIFF.html">
   <front>
     <title>RIFF Tags</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -70,6 +70,16 @@
   <seriesInfo name="IFPI" value="3rd Edition" />
 </reference>
 
+<reference anchor="LCCN" target="https://www.loc.gov/marc/lccn.html">
+  <front>
+    <title>Library Of Congress Control Number</title>
+    <author>
+      <organization>United States Library Of Congress</organization>
+    </author>
+    <date month="October" year="1999"/>
+  </front>
+</reference>
+
 <reference anchor="ReplayGain" target="http://wiki.hydrogenaud.io/index.php?title=Replay_Gain_specification">
   <front>
     <title>ReplayGain 1.0 specification</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -27,6 +27,15 @@
   </front>
 </reference>
 
+<reference anchor="IMDb" target="https://imdb-api.com/api">
+  <front>
+    <title>IMDb API Documentation</title>
+    <author>
+      <organization>Internet Movie Database</organization>
+    </author>
+  </front>
+</reference>
+
 <reference anchor="ISBN" target="https://www.isbn-international.org/content/isbn-users-manual">
   <front>
     <title>ISBN Users' Manual</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -1,6 +1,15 @@
 
 {backmatter}
 
+<reference anchor="GS1" target="https://www.gs1.org/standards/barcodes-epcrfid-id-keys/gs1-general-specifications">
+  <front>
+    <title>GS1 General Specifications</title>
+    <author/>
+     <date month="January" year="2020" />
+  </front>
+  <seriesInfo name="GS1" value="20.0" />
+</reference>
+
 <reference anchor="IANADomains" target="https://www.iana.org/domains/root/db">
   <front>
     <title>IANA Root Zone Database</title>

--- a/rfc_backmatter_tags.md
+++ b/rfc_backmatter_tags.md
@@ -29,6 +29,17 @@
   <seriesInfo name="ISO" value="3166-1:2020" />
 </reference>
 
+<reference anchor="ISO4217" target="https://www.iso.org/iso-4217-currency-codes.html">
+  <front>
+    <title>ISO 4217 Currency codes</title>
+    <author>
+      <organization>International Organization for Standardization</organization>
+    </author>
+    <date month="August" year="2015"/>
+  </front>
+  <seriesInfo name="ISO" value="4217:2015" />
+</reference>
+
 <reference anchor="ISRC" target="https://www.ifpi.org/wp-content/uploads/2020/08/ISRC_Handbook.pdf">
   <front>
     <title>International Standard Recording Code (ISRC) Handbook</title>

--- a/tagging.md
+++ b/tagging.md
@@ -44,11 +44,6 @@ We also need an official list simply for developers to be able to display releva
 in their own design (if they choose to support a list of meta-information they **SHOULD** know
 which tag has the wanted meaning so that other apps could understand the same meaning).
 
-## Tag translations
-
-To be able to save tags from other systems to Matroska we need to translate them to
-our system. There is a translation table [on our site](othertagsystems/comparetable.html).
-
 ## Tag Formatting
 
 * The TagName **SHOULD** always be written in all capital letters and contain no space.

--- a/tagging.md
+++ b/tagging.md
@@ -24,10 +24,6 @@ In this way, it becomes possible to store any Tag as attributes of another tag.
 Multiple items **SHOULD** never be stored as a list in a single TagString. If there is more
 than one tag of a certain type to be stored, then more than one SimpleTag **SHOULD** be used.
 
-For authoring Tags outside of EBML, the [following XML syntax is proposed](https://www.matroska.org/files/tags/matroskatags.dtd) 
-[used in mkvmerge](https://mkvtoolnix.download/doc/mkvmerge.html#mkvmerge.tags). Binary data
-**SHOULD** be stored using BASE64 encoding if it is being stored at authoring time.
-
 ## Why official tags matter
 
 There is a debate between people who think all tags **SHOULD** be free and those who think


### PR DESCRIPTION
Also remove some text that is only meant for the website, not the specs.